### PR TITLE
feat: Tower Game — hold-to-fill pressure game with forfeits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 @AGENTS.md
+
+## Commands
+
+```bash
+npm run dev      # Start development server (http://localhost:3000)
+npm run build    # Production build
+npm run lint     # ESLint
+npm run test     # Run all tests with vitest
+npx vitest run src/path/to/file.test.ts  # Run a single test file
+```
+
+## Architecture
+
+**Drink Roulette MVP** — a mobile web app where bar patrons at a table scan a QR code, play a roulette wheel game, and the loser pays for a round of drinks via Apple/Google Pay.
+
+### Tech Stack
+- **Next.js 16** (App Router) + React 19 + TypeScript
+- **Pusher** — real-time WebSocket pub/sub (avoids long-running server processes on Vercel)
+- **Upstash Redis** — serverless state management for table game sessions
+- **Stripe** — payment processing (currently stubbed; webhook at `/api/webhooks/stripe`)
+- **Tailwind CSS v4** + custom OLED dark theme
+
+### Request/Data Flow
+
+1. Host visits `/table/[tableId]` → sees the bar menu + "Play Drink Roulette" CTA
+2. Host clicks CTA → `POST /api/game/create` → Redis key `table:{tableId}:game` created with `status: 'GATHERING'` → Pusher event `game-updated` broadcast on channel `table-{tableId}`
+3. Guests on same page see `GameOverlay` appear (via Pusher) → enter nickname/emoji → `POST /api/game/join`
+4. Host clicks "Spin Wheel" → `POST /api/game/spin` → loser selected randomly → Pusher `spin_start` event with `{ loserId, targetEndTime }` broadcast to all clients
+5. All clients start spin animation locally, synchronized via `targetEndTime`
+6. Loser sees `PaymentScreen`, winners see `WinScreen` → loser pays via `POST /api/game/pay` → Pusher `game-paid` closes overlay for everyone
+
+### Key Files
+
+| Path | Purpose |
+|------|---------|
+| `src/app/table/[tableId]/page.tsx` | Main table page: menu + game creation |
+| `src/components/GameOverlay.tsx` | Real-time game state management; renders lobby/spin/payment/win screens |
+| `src/components/SpinWheel.tsx` | CSS animation wheel, driven by `loserId` prop |
+| `src/components/PaymentScreen.tsx` | Loser's payment UI; 2-min timeout enforced client-side |
+| `src/lib/pusher-server.ts` | Server Pusher instance |
+| `src/lib/pusher-client.ts` | Singleton client Pusher instance (browser only) |
+| `src/lib/redis.ts` | Upstash Redis singleton |
+| `src/types/game.ts` | `GameState` and `PlayerProfile` types |
+| `src/data/menu.ts` | Full bar menu data |
+
+### API Routes (`src/app/api/game/`)
+
+| Route | Action |
+|-------|--------|
+| `create` | Creates new game in Redis, broadcasts `game-updated` |
+| `join` | Adds player to `players[]`, broadcasts `game-updated` |
+| `spin` | Picks random loser, sets `status: 'SPINNING'`, broadcasts `spin_start` with `targetEndTime` |
+| `pay` | Sets `status: 'PAID'`, broadcasts `game-paid` |
+| `cancel` | Host disconnects; cancels game, broadcasts `lobby_closed` |
+| `leave` | Guest disconnects during `GATHERING` |
+| `timeout` | 2-min payment timeout enforced by host client; broadcasts `payment_timeout` |
+| `[tableId]` | GET current game state from Redis |
+
+### Design System
+
+See `design-system/drink-roulette-mvp/MASTER.md` for the full design system spec.
+
+- **Style:** Retro-Futurism / OLED dark mode (`#020617` background)
+- **Fonts:** `font-display` = Fredoka (headings), `font-sans` = Inter (body)
+- **Custom colors:** `primary` (#E11D48), `neon-violet` (#8B5CF6), `neon-rose` (#F43F5E), `neon-emerald` (#10B981)
+- **Custom shadows:** `shadow-neon-violet`, `shadow-neon-rose`, `shadow-neon-emerald`
+- **Anti-patterns:** No emojis as icons (use Lucide SVG), all clickable elements need `cursor-pointer`, transitions 150–300ms
+
+### Required Environment Variables
+
+```
+UPSTASH_REDIS_REST_URL
+UPSTASH_REDIS_REST_TOKEN
+PUSHER_APP_ID
+NEXT_PUBLIC_PUSHER_KEY
+PUSHER_SECRET
+NEXT_PUBLIC_PUSHER_CLUSTER
+```
+
+### Pusher Channel Convention
+
+Each table uses channel `table-{tableId}`. Events: `game-updated`, `spin_start`, `game-paid`, `lobby_closed`, `payment_timeout`.
+
+### Path Alias
+
+`@/` maps to `src/` (configured in both `tsconfig.json` and `vitest.config.ts`).

--- a/src/app/api/game/pay/route.ts
+++ b/src/app/api/game/pay/route.ts
@@ -22,11 +22,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Game already paid' }, { status: 400 });
     }
 
-    // Update state to PAID
+    // Update state to PAID and delete the key so a new game can be created
     gameState.status = 'PAID';
-
-    // Save to Redis
-    await redis.set(gameKey, gameState, { ex: 3600 });
+    await redis.del(gameKey);
 
     try {
       // Trigger game-paid event

--- a/src/app/api/tower/[tableId]/route.ts
+++ b/src/app/api/tower/[tableId]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { TowerState } from '@/types/tower';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ tableId: string }> }
+) {
+  try {
+    const { tableId } = await params;
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+    if (!state) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json({ game: state });
+  } catch (error) {
+    console.error('Failed to get tower state:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/__tests__/edgecases.test.ts
+++ b/src/app/api/tower/__tests__/edgecases.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, vi, beforeEach } from 'vitest';
+
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockDel = vi.fn();
+const mockTrigger = vi.fn();
+
+vi.mock('@/lib/redis', () => ({
+  redis: {
+    get: mockGet,
+    set: mockSet,
+    del: mockDel,
+    exists: vi.fn().mockResolvedValue(0),
+  },
+}));
+vi.mock('@/lib/pusher-server', () => ({
+  serverPusher: { trigger: mockTrigger },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTrigger.mockResolvedValue(undefined);
+  mockSet.mockResolvedValue('OK');
+  mockDel.mockResolvedValue(1);
+});
+
+test('close: deletes Redis key and fires tower-lobby-closed', async () => {
+  const { POST } = await import('../close/route');
+  const req = new Request('http://localhost/api/tower/close', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  expect(mockDel).toHaveBeenCalledWith('table:t1:tower');
+  expect(mockTrigger).toHaveBeenCalledWith('table-t1', 'tower-lobby-closed', {});
+});
+
+test('leave: removes player from LOBBY state', async () => {
+  const { POST } = await import('../leave/route');
+  mockGet.mockResolvedValue({
+    status: 'LOBBY',
+    host: 'u1',
+    players: [
+      { userId: 'u1', nickname: 'Host', emoji: '👑' },
+      { userId: 'u2', nickname: 'Guest', emoji: '😎' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  });
+  const req = new Request('http://localhost/api/tower/leave', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const savedState = mockSet.mock.calls[0][1];
+  expect(savedState.players).toHaveLength(1);
+  expect(savedState.players[0].userId).toBe('u1');
+});
+
+test('leave: no-op if game not in LOBBY', async () => {
+  const { POST } = await import('../leave/route');
+  mockGet.mockResolvedValue({ status: 'PLAYER_TURN' });
+  const req = new Request('http://localhost/api/tower/leave', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  expect(mockSet).not.toHaveBeenCalled();
+});
+
+test('leave: no-op if game not found', async () => {
+  const { POST } = await import('../leave/route');
+  mockGet.mockResolvedValue(null);
+  const req = new Request('http://localhost/api/tower/leave', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  expect(mockSet).not.toHaveBeenCalled();
+});

--- a/src/app/api/tower/__tests__/routes.test.ts
+++ b/src/app/api/tower/__tests__/routes.test.ts
@@ -1,0 +1,358 @@
+import { expect, test, vi, beforeEach } from 'vitest';
+import { TowerState } from '@/types/tower';
+
+// Shared mocks
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockDel = vi.fn();
+const mockExists = vi.fn();
+const mockTrigger = vi.fn();
+
+vi.mock('@/lib/redis', () => ({
+  redis: {
+    get: mockGet,
+    set: mockSet,
+    del: mockDel,
+    exists: mockExists,
+  },
+}));
+vi.mock('@/lib/pusher-server', () => ({
+  serverPusher: { trigger: mockTrigger },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTrigger.mockResolvedValue(undefined);
+  mockSet.mockResolvedValue('OK');
+  mockDel.mockResolvedValue(1);
+});
+
+// ─── create ────────────────────────────────────────────────────────────────
+
+test('create: success', async () => {
+  const { POST } = await import('../create/route');
+  mockExists.mockResolvedValue(0);
+  const req = new Request('http://localhost/api/tower/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      tableId: 't1',
+      roundId: 'r1',
+      hostProfile: { userId: 'u1', nickname: 'Host', emoji: '👑' },
+    }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.status).toBe('LOBBY');
+  expect(data.game.players).toHaveLength(1);
+});
+
+test('create: 400 if tower game exists', async () => {
+  const { POST } = await import('../create/route');
+  mockExists.mockResolvedValueOnce(1); // tower key exists
+  const req = new Request('http://localhost/api/tower/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      tableId: 't1',
+      roundId: 'r1',
+      hostProfile: { userId: 'u1', nickname: 'Host', emoji: '👑' },
+    }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+});
+
+test('create: 400 if roulette running', async () => {
+  const { POST } = await import('../create/route');
+  mockExists
+    .mockResolvedValueOnce(0) // tower key absent
+    .mockResolvedValueOnce(1); // roulette key present
+  const req = new Request('http://localhost/api/tower/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      tableId: 't1',
+      roundId: 'r1',
+      hostProfile: { userId: 'u1', nickname: 'Host', emoji: '👑' },
+    }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+});
+
+test('create: stores hostDare when provided', async () => {
+  const { POST } = await import('../create/route');
+  mockExists.mockResolvedValue(0);
+  const req = new Request('http://localhost/api/tower/create', {
+    method: 'POST',
+    body: JSON.stringify({
+      tableId: 't1',
+      roundId: 'r1',
+      hostProfile: { userId: 'u1', nickname: 'Host', emoji: '👑' },
+      hostDare: 'Do a backflip',
+    }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.hostDare).toBe('Do a backflip');
+});
+
+// ─── join ──────────────────────────────────────────────────────────────────
+
+test('join: success', async () => {
+  const { POST } = await import('../join/route');
+  const lobbyState: TowerState = {
+    status: 'LOBBY',
+    host: 'u1',
+    players: [{ userId: 'u1', nickname: 'Host', emoji: '👑' }],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockGet.mockResolvedValue(lobbyState);
+  const req = new Request('http://localhost/api/tower/join', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', playerProfile: { userId: 'u2', nickname: 'Guest', emoji: '😎' } }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.players).toHaveLength(2);
+});
+
+test('join: 400 if not LOBBY', async () => {
+  const { POST } = await import('../join/route');
+  mockGet.mockResolvedValue({ status: 'PLAYER_TURN', players: [] });
+  const req = new Request('http://localhost/api/tower/join', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', playerProfile: { userId: 'u2', nickname: 'G', emoji: '😎' } }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+});
+
+test('join: deduplication — same player not added twice', async () => {
+  const { POST } = await import('../join/route');
+  const lobbyState: TowerState = {
+    status: 'LOBBY',
+    host: 'u1',
+    players: [
+      { userId: 'u1', nickname: 'Host', emoji: '👑' },
+      { userId: 'u2', nickname: 'Guest', emoji: '😎' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockGet.mockResolvedValue(lobbyState);
+  const req = new Request('http://localhost/api/tower/join', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', playerProfile: { userId: 'u2', nickname: 'Guest', emoji: '😎' } }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.players).toHaveLength(2);
+});
+
+// ─── start ─────────────────────────────────────────────────────────────────
+
+test('start: success', async () => {
+  const { POST } = await import('../start/route');
+  const state: TowerState = {
+    status: 'LOBBY',
+    host: 'u1',
+    players: [
+      { userId: 'u1', nickname: 'A', emoji: '👑' },
+      { userId: 'u2', nickname: 'B', emoji: '😎' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockGet.mockResolvedValue(state);
+  const req = new Request('http://localhost/api/tower/start', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u1' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.status).toBe('PLAYER_TURN');
+});
+
+test('start: 403 non-host', async () => {
+  const { POST } = await import('../start/route');
+  mockGet.mockResolvedValue({
+    status: 'LOBBY',
+    host: 'u1',
+    players: [
+      { userId: 'u1', nickname: 'A', emoji: '👑' },
+      { userId: 'u2', nickname: 'B', emoji: '😎' },
+    ],
+  });
+  const req = new Request('http://localhost/api/tower/start', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(403);
+});
+
+test('start: 400 with < 2 players', async () => {
+  const { POST } = await import('../start/route');
+  mockGet.mockResolvedValue({
+    status: 'LOBBY',
+    host: 'u1',
+    players: [{ userId: 'u1', nickname: 'A', emoji: '👑' }],
+  });
+  const req = new Request('http://localhost/api/tower/start', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u1' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(400);
+});
+
+// ─── submit-turn ───────────────────────────────────────────────────────────
+
+const twoPlayerState = (): TowerState => ({
+  status: 'PLAYER_TURN',
+  host: 'u1',
+  players: [
+    { userId: 'u1', nickname: 'A', emoji: '👑' },
+    { userId: 'u2', nickname: 'B', emoji: '😎' },
+  ],
+  roundId: 'r1',
+  currentPlayerIndex: 0,
+  results: [],
+});
+
+test('submit-turn: advances to next player (not last)', async () => {
+  const { POST } = await import('../submit-turn/route');
+  mockGet.mockResolvedValue(twoPlayerState());
+  const req = new Request('http://localhost/api/tower/submit-turn', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u1', fill: 0.6 }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const savedState = mockSet.mock.calls[0][1] as TowerState;
+  expect(savedState.currentPlayerIndex).toBe(1);
+  expect(savedState.results).toHaveLength(1);
+  expect(savedState.results[0].busted).toBe(false);
+});
+
+test('submit-turn: busted flag set when fill >= 1.0', async () => {
+  const { POST } = await import('../submit-turn/route');
+  mockGet.mockResolvedValue(twoPlayerState());
+  const req = new Request('http://localhost/api/tower/submit-turn', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u1', fill: 1.2 }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const savedState = mockSet.mock.calls[0][1] as TowerState;
+  expect(savedState.results[0].busted).toBe(true);
+  expect(savedState.results[0].fill).toBe(1.0); // clamped
+});
+
+test('submit-turn: 403 wrong player', async () => {
+  const { POST } = await import('../submit-turn/route');
+  mockGet.mockResolvedValue(twoPlayerState()); // currentPlayerIndex=0 → u1's turn
+  const req = new Request('http://localhost/api/tower/submit-turn', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2', fill: 0.5 }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(403);
+});
+
+test('submit-turn: ROUND_END when last player, winnerId computed', async () => {
+  const { POST } = await import('../submit-turn/route');
+  const state = twoPlayerState();
+  // u1 already went with fill=0.5
+  state.results = [{ userId: 'u1', fill: 0.5, busted: false }];
+  state.currentPlayerIndex = 1;
+  mockGet.mockResolvedValue(state);
+
+  const req = new Request('http://localhost/api/tower/submit-turn', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2', fill: 0.7 }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const savedState = mockSet.mock.calls[0][1] as TowerState;
+  expect(savedState.status).toBe('ROUND_END');
+  // u2 has higher fill (0.7 > 0.5) without busting
+  expect(savedState.winnerId).toBe('u2');
+  expect(savedState.forfeitText).toBeDefined();
+  expect(savedState.forfeitCategory).toBeDefined();
+});
+
+test('submit-turn: all-bust scenario picks max-fill winner', async () => {
+  const { POST } = await import('../submit-turn/route');
+  const state = twoPlayerState();
+  state.results = [{ userId: 'u1', fill: 1.0, busted: true }];
+  state.currentPlayerIndex = 1;
+  mockGet.mockResolvedValue(state);
+
+  const req = new Request('http://localhost/api/tower/submit-turn', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', userId: 'u2', fill: 1.05 }), // also busted
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const savedState = mockSet.mock.calls[0][1] as TowerState;
+  expect(savedState.status).toBe('ROUND_END');
+  // Both busted: u2 submitted 1.05 → clamped to 1.0, u1 also 1.0 — tie → first in reduce wins
+  // (both clamped to 1.0, so reduce picks whichever comes first with >, u1 wins)
+  expect(['u1', 'u2']).toContain(savedState.winnerId);
+});
+
+// ─── forfeit ───────────────────────────────────────────────────────────────
+
+test('forfeit: success', async () => {
+  const { POST } = await import('../forfeit/route');
+  const state: TowerState = {
+    status: 'ROUND_END',
+    host: 'u1',
+    players: [
+      { userId: 'u1', nickname: 'A', emoji: '👑' },
+      { userId: 'u2', nickname: 'B', emoji: '😎' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 1,
+    results: [],
+    winnerId: 'u1',
+    forfeitText: 'Do a backflip',
+    forfeitCategory: 'dare',
+  };
+  mockGet.mockResolvedValue(state);
+  const req = new Request('http://localhost/api/tower/forfeit', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', winnerId: 'u1', targetUserId: 'u2' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.game.status).toBe('FORFEIT');
+  expect(data.game.forfeit.toUserId).toBe('u2');
+  expect(data.game.forfeit.category).toBe('dare');
+});
+
+test('forfeit: 403 non-winner', async () => {
+  const { POST } = await import('../forfeit/route');
+  mockGet.mockResolvedValue({
+    status: 'ROUND_END',
+    winnerId: 'u1',
+    forfeitText: 'test',
+    forfeitCategory: 'drink',
+  });
+  const req = new Request('http://localhost/api/tower/forfeit', {
+    method: 'POST',
+    body: JSON.stringify({ tableId: 't1', winnerId: 'u2', targetUserId: 'u1' }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(403);
+});

--- a/src/app/api/tower/close/route.ts
+++ b/src/app/api/tower/close/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId } = body;
+
+    if (!tableId) {
+      return NextResponse.json({ error: 'Missing tableId' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    await redis.del(key);
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-lobby-closed', {});
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to close tower game:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/create/route.ts
+++ b/src/app/api/tower/create/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState } from '@/types/tower';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, roundId, hostProfile, hostDare } = body;
+
+    if (!tableId || !roundId || !hostProfile) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const towerKey = `table:${tableId}:tower`;
+    const gameKey = `table:${tableId}:game`;
+
+    if (await redis.exists(towerKey)) {
+      return NextResponse.json({ error: 'Tower game already exists' }, { status: 400 });
+    }
+    if (await redis.exists(gameKey)) {
+      return NextResponse.json({ error: 'Roulette game already running' }, { status: 400 });
+    }
+
+    const state: TowerState = {
+      status: 'LOBBY',
+      host: hostProfile.userId,
+      players: [hostProfile],
+      roundId,
+      currentPlayerIndex: 0,
+      results: [],
+      ...(hostDare?.trim() ? { hostDare: hostDare.trim() } : {}),
+    };
+
+    await redis.set(towerKey, state, { ex: 3600 });
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-updated', state);
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true, game: state });
+  } catch (error) {
+    console.error('Failed to create tower game:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/forfeit/route.ts
+++ b/src/app/api/tower/forfeit/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState, TowerForfeit } from '@/types/tower';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, winnerId, targetUserId } = body;
+
+    if (!tableId || !winnerId || !targetUserId) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+
+    if (!state) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+    if (state.status !== 'ROUND_END') {
+      return NextResponse.json({ error: 'Not in ROUND_END state' }, { status: 400 });
+    }
+    if (state.winnerId !== winnerId) {
+      return NextResponse.json({ error: 'Only the winner can assign the forfeit' }, { status: 403 });
+    }
+
+    const forfeit: TowerForfeit = {
+      fromUserId: winnerId,
+      toUserId: targetUserId,
+      text: state.forfeitText!,
+      category: state.forfeitCategory!,
+    };
+
+    state.status = 'FORFEIT';
+    state.forfeit = forfeit;
+
+    await redis.set(key, state, { ex: 3600 });
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-forfeit', { forfeit });
+      await serverPusher.trigger(`table-${tableId}`, 'tower-updated', state);
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true, game: state });
+  } catch (error) {
+    console.error('Failed to assign forfeit:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/join/route.ts
+++ b/src/app/api/tower/join/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState } from '@/types/tower';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, playerProfile } = body;
+
+    if (!tableId || !playerProfile) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+
+    if (!state) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+    if (state.status !== 'LOBBY') {
+      return NextResponse.json({ error: 'Game has already started' }, { status: 400 });
+    }
+
+    // Deduplicate by userId
+    const alreadyIn = state.players.some(p => p.userId === playerProfile.userId);
+    if (!alreadyIn) {
+      state.players.push(playerProfile);
+    }
+
+    await redis.set(key, state, { ex: 3600 });
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-updated', state);
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true, game: state });
+  } catch (error) {
+    console.error('Failed to join tower game:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/leave/route.ts
+++ b/src/app/api/tower/leave/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState } from '@/types/tower';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, userId } = body;
+
+    if (!tableId || !userId) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+
+    if (!state || state.status !== 'LOBBY') {
+      return NextResponse.json({ success: true }); // no-op
+    }
+
+    state.players = state.players.filter(p => p.userId !== userId);
+    await redis.set(key, state, { ex: 3600 });
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-updated', state);
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to leave tower game:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/start/route.ts
+++ b/src/app/api/tower/start/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState } from '@/types/tower';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, userId } = body;
+
+    if (!tableId || !userId) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+
+    if (!state) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+    if (state.host !== userId) {
+      return NextResponse.json({ error: 'Only the host can start the game' }, { status: 403 });
+    }
+    if (state.status !== 'LOBBY') {
+      return NextResponse.json({ error: 'Game is not in LOBBY state' }, { status: 400 });
+    }
+    if (state.players.length < 2) {
+      return NextResponse.json({ error: 'Need at least 2 players to start' }, { status: 400 });
+    }
+
+    state.status = 'PLAYER_TURN';
+    state.currentPlayerIndex = 0;
+
+    await redis.set(key, state, { ex: 3600 });
+
+    const firstPlayer = state.players[0];
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-updated', state);
+      await serverPusher.trigger(`table-${tableId}`, 'tower-turn-start', {
+        playerId: firstPlayer.userId,
+        playerIndex: 0,
+      });
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true, game: state });
+  } catch (error) {
+    console.error('Failed to start tower game:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/tower/submit-turn/route.ts
+++ b/src/app/api/tower/submit-turn/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/lib/redis';
+import { serverPusher } from '@/lib/pusher-server';
+import { TowerState, TowerTurnResult } from '@/types/tower';
+import { pickRandomForfeit } from '@/data/forfeits';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { tableId, userId, fill } = body;
+
+    if (!tableId || !userId || typeof fill !== 'number') {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const key = `table:${tableId}:tower`;
+    const state = await redis.get<TowerState>(key);
+
+    if (!state) {
+      return NextResponse.json({ error: 'Game not found' }, { status: 404 });
+    }
+    if (state.status !== 'PLAYER_TURN') {
+      return NextResponse.json({ error: 'Not in PLAYER_TURN state' }, { status: 400 });
+    }
+
+    const currentPlayer = state.players[state.currentPlayerIndex];
+    if (!currentPlayer || currentPlayer.userId !== userId) {
+      return NextResponse.json({ error: 'Not your turn' }, { status: 403 });
+    }
+
+    const busted = fill >= 1.0;
+    const result: TowerTurnResult = {
+      userId,
+      fill: Math.min(fill, 1.0),
+      busted,
+    };
+    state.results.push(result);
+
+    const isLastPlayer = state.results.length === state.players.length;
+
+    if (!isLastPlayer) {
+      state.currentPlayerIndex += 1;
+      const nextPlayer = state.players[state.currentPlayerIndex];
+
+      await redis.set(key, state, { ex: 3600 });
+
+      try {
+        await serverPusher.trigger(`table-${tableId}`, 'tower-turn-result', { result });
+        await serverPusher.trigger(`table-${tableId}`, 'tower-turn-start', {
+          playerId: nextPlayer.userId,
+          playerIndex: state.currentPlayerIndex,
+        });
+      } catch (pusherError) {
+        console.error('Failed to trigger Pusher event:', pusherError);
+      }
+
+      return NextResponse.json({ success: true });
+    }
+
+    // All players done — compute winner and wrap up round
+    const nonBusted = state.results.filter(r => !r.busted);
+    let winnerId: string;
+
+    if (nonBusted.length > 0) {
+      // Closest to 1.0 without busting
+      const winner = nonBusted.reduce((best, r) => (r.fill > best.fill ? r : best));
+      winnerId = winner.userId;
+    } else {
+      // All busted — highest fill still wins (closest to the edge)
+      const winner = state.results.reduce((best, r) => (r.fill > best.fill ? r : best));
+      winnerId = winner.userId;
+    }
+
+    const picked = pickRandomForfeit(state.hostDare);
+    state.status = 'ROUND_END';
+    state.winnerId = winnerId;
+    state.forfeitCategory = picked.category;
+    state.forfeitText = picked.text;
+
+    await redis.set(key, state, { ex: 3600 });
+
+    try {
+      await serverPusher.trigger(`table-${tableId}`, 'tower-turn-result', { result });
+      await serverPusher.trigger(`table-${tableId}`, 'tower-round-end', {
+        winnerId,
+        forfeitCategory: picked.category,
+        forfeitText: picked.text,
+        results: state.results,
+      });
+    } catch (pusherError) {
+      console.error('Failed to trigger Pusher event:', pusherError);
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to submit turn:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/table/[tableId]/__tests__/page.test.tsx
+++ b/src/app/table/[tableId]/__tests__/page.test.tsx
@@ -3,9 +3,12 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import React, { Suspense } from 'react';
 import Page from '../page';
 
-// Mock GameOverlay to prevent Pusher errors
+// Mock overlays to prevent Pusher/fetch errors
 vi.mock('@/components/GameOverlay', () => ({
   default: () => <div data-testid="game-overlay-mock" />
+}));
+vi.mock('@/components/TowerOverlay', () => ({
+  default: () => <div data-testid="tower-overlay-mock" />
 }));
 
 test('opens bottom sheet and shows stepper', async () => {
@@ -19,7 +22,7 @@ test('opens bottom sheet and shows stepper', async () => {
     );
   });
 
-  const button = await screen.findByText('Play Drink Roulette 🎰');
+  const button = await screen.findByText('Play Drink Roulette');
   fireEvent.click(button);
   
   expect(screen.getByText('Set the Stakes')).toBeTruthy();

--- a/src/app/table/[tableId]/page.tsx
+++ b/src/app/table/[tableId]/page.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import React, { use, useState } from "react";
+import React, { use, useState, useEffect } from "react";
+import dynamic from "next/dynamic";
 import { menuData } from "@/data/menu";
 import Menu from "@/components/Menu";
 import GameOverlay from "@/components/GameOverlay";
+import { GameState } from "@/types/game";
+
+const TowerOverlay = dynamic(() => import("@/components/TowerOverlay"), {
+  ssr: false,
+  loading: () => null,
+});
 
 type Props = {
   params: Promise<{
@@ -13,60 +20,117 @@ type Props = {
 
 export default function TableMenuPage({ params }: Props) {
   const { tableId } = use(params);
-  
+
   // Flatten menu items for easy lookup
   const allItems = menuData.flatMap(category => category.items);
-  
+
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [isTowerSheetOpen, setIsTowerSheetOpen] = useState(false);
   const [selectedDrink, setSelectedDrink] = useState(allItems[0]?.name || "Tequila Shots");
   const [quantity, setQuantity] = useState(1);
-  
+  const [hostDare, setHostDare] = useState("");
+
+  const [isRouletteActive, setIsRouletteActive] = useState(false);
+  const [isTowerActive, setIsTowerActive] = useState(false);
+  const [hostCreatedGame, setHostCreatedGame] = useState<GameState | null>(null);
+
   const selectedItem = allItems.find(item => item.name === selectedDrink);
-  const price = selectedItem 
-    ? typeof selectedItem.price === 'string' 
-      ? parseFloat(selectedItem.price.replace('$', '')) 
-      : selectedItem.price 
+  const price = selectedItem
+    ? typeof selectedItem.price === "string"
+      ? parseFloat(selectedItem.price.replace("$", ""))
+      : selectedItem.price
     : 10;
 
+  // Hydrate initial active state from server
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/game/${tableId}`)
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null),
+      fetch(`/api/tower/${tableId}`)
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ]).then(([g, t]) => {
+      setIsRouletteActive(!!g?.game);
+      setIsTowerActive(!!t?.game);
+    });
+  }, [tableId]);
+
   const handleCreateGame = async () => {
-    let userId = localStorage.getItem('demo_user_id');
+    let userId = localStorage.getItem("demo_user_id");
     if (!userId) {
       userId = `host_${Math.random().toString(36).substr(2, 9)}`;
-      localStorage.setItem('demo_user_id', userId);
+      localStorage.setItem("demo_user_id", userId);
     }
 
     try {
-      const response = await fetch('/api/game/create', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+      const response = await fetch("/api/game/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           tableId,
           roundId: `round_${Date.now()}`,
           hostProfile: {
             userId,
-            nickname: 'Host Master',
-            emoji: '👑',
+            nickname: "Host Master",
+            emoji: "👑",
           },
           drinkType: selectedDrink,
-          drinkQuantity: quantity
+          drinkQuantity: quantity,
         }),
       });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
+      const data = await response.json();
       setIsBottomSheetOpen(false);
+      if (data.game) setHostCreatedGame(data.game);
     } catch (error) {
-      console.error('Failed to create game:', error);
+      console.error("Failed to create game:", error);
       setIsBottomSheetOpen(false);
     }
   };
 
+  const handleCreateTowerGame = async () => {
+    let userId = localStorage.getItem("demo_user_id");
+    if (!userId) {
+      userId = `host_${Math.random().toString(36).substr(2, 9)}`;
+      localStorage.setItem("demo_user_id", userId);
+    }
+
+    try {
+      const response = await fetch("/api/tower/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tableId,
+          roundId: `tower_${Date.now()}`,
+          hostProfile: {
+            userId,
+            nickname: "Host Master",
+            emoji: "👑",
+          },
+          hostDare: hostDare.trim() || undefined,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      setIsTowerSheetOpen(false);
+      setHostDare("");
+    } catch (error) {
+      console.error("Failed to create tower game:", error);
+      setIsTowerSheetOpen(false);
+    }
+  };
+
+  const isAnyGameActive = isRouletteActive || isTowerActive;
+
   return (
-    <div className="min-h-screen bg-background text-foreground pb-28 relative">
-      <GameOverlay tableId={tableId} />
-      
+    <div className="min-h-screen bg-background text-foreground pb-36 relative">
+      <GameOverlay tableId={tableId} onGameActiveChange={setIsRouletteActive} hostInitiatedGame={hostCreatedGame} />
+      <TowerOverlay tableId={tableId} onGameActiveChange={setIsTowerActive} />
+
       {/* Header */}
       <header className="pt-10 pb-6 px-6 bg-background z-10 border-b border-surface">
         <div className="flex justify-between items-center max-w-4xl mx-auto">
@@ -74,33 +138,43 @@ export default function TableMenuPage({ params }: Props) {
             <h1 className="text-3xl font-display font-black bg-gradient-to-r from-neon-violet to-primary bg-clip-text text-transparent">
               Neon Nights
             </h1>
-            <p className="text-sm text-slate-400 mt-1">
-              Table #{tableId} • Menu
-            </p>
+            <p className="text-sm text-slate-400 mt-1">Table #{tableId} • Menu</p>
           </div>
         </div>
       </header>
 
-      {/* Menu Component handles its own categories, navigation, and sticky behavior */}
+      {/* Menu Component */}
       <Menu />
 
-      {/* Floating CTA Button */}
-      <div className="fixed bottom-0 left-0 right-0 p-6 bg-gradient-to-t from-background via-background/90 to-transparent pointer-events-none flex justify-center pb-8 z-20">
-        <button 
+      {/* Floating CTA Buttons */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-background via-background/90 to-transparent pointer-events-none flex flex-col items-center gap-3 pb-8 z-20">
+        <button
           onClick={() => setIsBottomSheetOpen(true)}
-          className="pointer-events-auto flex items-center justify-center gap-3 w-full max-w-sm py-4 px-6 rounded-full bg-gradient-to-r from-neon-violet to-primary shadow-neon-violet text-white font-bold text-lg font-display hover:scale-[1.02] active:scale-95 transition-all duration-200"
+          disabled={isAnyGameActive}
+          className="pointer-events-auto flex items-center justify-center gap-3 w-full max-w-sm py-4 px-6 rounded-full bg-gradient-to-r from-neon-violet to-primary shadow-neon-violet text-white font-bold text-lg font-display hover:scale-[1.02] active:scale-95 transition-all duration-200 disabled:opacity-40 disabled:scale-100 disabled:cursor-not-allowed cursor-pointer"
         >
-          <span>Play Drink Roulette 🎰</span>
+          Play Drink Roulette
+        </button>
+        <button
+          onClick={() => setIsTowerSheetOpen(true)}
+          disabled={isAnyGameActive}
+          className="pointer-events-auto flex items-center justify-center gap-3 w-full max-w-sm py-4 px-6 rounded-full bg-gradient-to-r from-neon-rose to-orange-500 shadow-neon-rose text-white font-bold text-lg font-display hover:scale-[1.02] active:scale-95 transition-all duration-200 disabled:opacity-40 disabled:scale-100 disabled:cursor-not-allowed cursor-pointer"
+        >
+          Play Tower Game
         </button>
       </div>
 
-      {/* Bottom Sheet */}
+      {/* Roulette Bottom Sheet */}
       {isBottomSheetOpen && (
         <div className="fixed inset-0 z-40 flex items-end bg-black/50">
           <div className="bg-slate-900 w-full p-6 rounded-t-2xl">
             <h2 className="text-xl font-bold mb-4 text-white">Set the Stakes</h2>
-            <select value={selectedDrink} onChange={(e) => setSelectedDrink(e.target.value)} className="w-full bg-slate-800 p-2 rounded mb-4 text-white">
-              {menuData.map((category) => (
+            <select
+              value={selectedDrink}
+              onChange={e => setSelectedDrink(e.target.value)}
+              className="w-full bg-slate-800 p-2 rounded mb-4 text-white"
+            >
+              {menuData.map(category => (
                 <optgroup key={category.category} label={category.category}>
                   {category.items.map((item, idx) => (
                     <option key={`${item.name}-${idx}`} value={item.name}>
@@ -111,13 +185,73 @@ export default function TableMenuPage({ params }: Props) {
               ))}
             </select>
             <div className="flex items-center gap-4 mb-6">
-              <button onClick={() => setQuantity(Math.max(1, quantity - 1))} className="px-4 py-2 bg-slate-800 rounded text-white">-</button>
+              <button
+                onClick={() => setQuantity(Math.max(1, quantity - 1))}
+                className="px-4 py-2 bg-slate-800 rounded text-white cursor-pointer"
+              >
+                -
+              </button>
               <span className="text-xl text-white">{quantity}</span>
-              <button onClick={() => setQuantity(quantity + 1)} className="px-4 py-2 bg-slate-800 rounded text-white">+</button>
+              <button
+                onClick={() => setQuantity(quantity + 1)}
+                className="px-4 py-2 bg-slate-800 rounded text-white cursor-pointer"
+              >
+                +
+              </button>
             </div>
-            <button onClick={handleCreateGame} className="w-full bg-violet-600 p-3 rounded font-bold text-white">
-              Create Game (${(price * quantity).toFixed(2)})
-            </button>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setIsBottomSheetOpen(false)}
+                className="flex-1 py-3 bg-slate-800 text-slate-300 rounded font-bold cursor-pointer hover:bg-slate-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateGame}
+                className="flex-1 py-3 bg-violet-600 rounded font-bold text-white cursor-pointer hover:bg-violet-500 transition-colors"
+              >
+                Create Game (${(price * quantity).toFixed(2)})
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Tower Game Bottom Sheet */}
+      {isTowerSheetOpen && (
+        <div className="fixed inset-0 z-40 flex items-end bg-black/50">
+          <div className="bg-slate-900 w-full p-6 rounded-t-2xl">
+            <h2 className="text-xl font-bold mb-1 text-white">Tower Game</h2>
+            <p className="text-slate-400 text-sm mb-4">
+              Hold to fill the tower. Get closest to 82% without busting — winner picks a forfeit.
+            </p>
+            <label className="block text-sm font-medium text-slate-400 mb-1">
+              Custom Dare <span className="text-slate-600">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={hostDare}
+              onChange={e => setHostDare(e.target.value)}
+              placeholder="e.g. Do your best impression of someone here"
+              className="w-full px-4 py-2 bg-black/40 border border-slate-700 rounded-lg focus:ring-2 focus:ring-neon-rose focus:border-neon-rose outline-none text-white placeholder-slate-600 mb-4"
+            />
+            <p className="text-slate-600 text-xs mb-4">
+              Leave blank to use a random drink or pay forfeit instead.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => { setIsTowerSheetOpen(false); setHostDare(""); }}
+                className="flex-1 py-3 bg-slate-800 text-slate-300 rounded font-bold cursor-pointer hover:bg-slate-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateTowerGame}
+                className="flex-1 py-3 bg-gradient-to-r from-neon-rose to-orange-500 text-white rounded font-bold cursor-pointer hover:opacity-90 transition-all"
+              >
+                Create Game
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/GameOverlay.tsx
+++ b/src/components/GameOverlay.tsx
@@ -9,9 +9,11 @@ import WinScreen from './WinScreen';
 
 interface GameOverlayProps {
   tableId: string;
+  onGameActiveChange?: (active: boolean) => void;
+  hostInitiatedGame?: GameState | null;
 }
 
-export default function GameOverlay({ tableId }: GameOverlayProps) {
+export default function GameOverlay({ tableId, onGameActiveChange, hostInitiatedGame }: GameOverlayProps) {
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [nickname, setNickname] = useState('');
   const [emoji, setEmoji] = useState('🎲');
@@ -21,6 +23,17 @@ export default function GameOverlay({ tableId }: GameOverlayProps) {
   const [loserId, setLoserId] = useState<string | null>(null);
   const [showResolution, setShowResolution] = useState(false);
   const [isPaying, setIsPaying] = useState(false);
+
+  useEffect(() => {
+    onGameActiveChange?.(gameState !== null);
+  }, [gameState, onGameActiveChange]);
+
+  // Host fallback: show overlay immediately from API response without waiting for Pusher
+  useEffect(() => {
+    if (hostInitiatedGame) {
+      setGameState(hostInitiatedGame);
+    }
+  }, [hostInitiatedGame]);
 
   useEffect(() => {
     // Basic local user ID for this demo
@@ -81,7 +94,11 @@ export default function GameOverlay({ tableId }: GameOverlayProps) {
     channel.bind('payment_timeout', () => setGameState(null));
 
     return () => {
-      channel.unbind_all();
+      channel.unbind('game-updated');
+      channel.unbind('spin_start');
+      channel.unbind('game-paid');
+      channel.unbind('lobby_closed');
+      channel.unbind('payment_timeout');
       channel.unsubscribe();
     };
   }, [tableId]);
@@ -178,6 +195,11 @@ export default function GameOverlay({ tableId }: GameOverlayProps) {
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
+      // Optimistically clear overlay — game-paid Pusher event will also clear other tabs
+      setGameState(null);
+      setShowResolution(false);
+      setIsPaying(false);
+      setLoserId(null);
     } catch (error) {
       console.error('Failed to pay:', error);
       setIsPaying(false);

--- a/src/components/TowerForfeitScreen.tsx
+++ b/src/components/TowerForfeitScreen.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { TowerState } from '@/types/tower';
+import { ForfeitCategory } from '@/data/forfeits';
+
+const CATEGORY_LABELS: Record<ForfeitCategory, string> = {
+  dare: 'Social Dare',
+  drink: 'Drink Up',
+  pay: 'Pay Up',
+};
+
+const CATEGORY_COLORS: Record<ForfeitCategory, string> = {
+  dare: 'from-amber-500 to-orange-500',
+  drink: 'from-neon-violet to-indigo-500',
+  pay: 'from-neon-rose to-primary',
+};
+
+interface TowerForfeitScreenProps {
+  towerState: TowerState;
+  userId: string | null;
+  onAssignForfeit: (targetUserId: string) => Promise<void>;
+  onClose: () => Promise<void>;
+}
+
+export default function TowerForfeitScreen({
+  towerState,
+  userId,
+  onAssignForfeit,
+  onClose,
+}: TowerForfeitScreenProps) {
+  const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
+  const [isAssigning, setIsAssigning] = useState(false);
+
+  const isWinner = userId === towerState.winnerId;
+  const isHost = userId === towerState.host;
+  const category = towerState.forfeitCategory!;
+  const forfeitText = towerState.forfeitText!;
+  const forfeit = towerState.forfeit;
+
+  const assignablePlayers = towerState.players.filter(p => p.userId !== towerState.winnerId);
+
+  const handleAssign = async () => {
+    if (!selectedTarget || isAssigning) return;
+    setIsAssigning(true);
+    try {
+      await onAssignForfeit(selectedTarget);
+    } finally {
+      setIsAssigning(false);
+    }
+  };
+
+  const categoryGradient = CATEGORY_COLORS[category] || CATEGORY_COLORS.dare;
+  const categoryLabel = CATEGORY_LABELS[category] || 'Forfeit';
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl shadow-neon-rose p-6 w-full max-w-md">
+      <h2 className="text-3xl font-display font-black text-center mb-4 bg-gradient-to-r from-neon-rose to-orange-400 bg-clip-text text-transparent">
+        Round Over!
+      </h2>
+
+      {/* Winner */}
+      {(() => {
+        const winner = towerState.players.find(p => p.userId === towerState.winnerId);
+        return winner ? (
+          <div className="text-center mb-4">
+            <p className="text-slate-400 text-sm">Winner</p>
+            <p className="text-2xl font-bold text-white">
+              {winner.emoji} {winner.nickname}
+              {winner.userId === userId && <span className="text-neon-emerald"> (You!)</span>}
+            </p>
+          </div>
+        ) : null;
+      })()}
+
+      {/* Forfeit card */}
+      <div className={`mb-6 p-4 rounded-xl bg-gradient-to-r ${categoryGradient} text-white`}>
+        <p className="text-xs font-bold uppercase tracking-widest opacity-80 mb-1">{categoryLabel}</p>
+        <p className="text-lg font-bold">{forfeitText}</p>
+      </div>
+
+      {/* Not yet assigned — winner picks */}
+      {!forfeit && isWinner && (
+        <div className="space-y-4">
+          <p className="text-slate-400 text-sm text-center">Pick who gets this forfeit:</p>
+          <div className="space-y-2">
+            {assignablePlayers.map(player => (
+              <button
+                key={player.userId}
+                onClick={() => setSelectedTarget(player.userId)}
+                className={`w-full flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-all ${
+                  selectedTarget === player.userId
+                    ? 'bg-rose-500/20 border-neon-rose text-white'
+                    : 'bg-slate-800 border-slate-700 text-slate-300 hover:bg-slate-700'
+                }`}
+              >
+                <span className="text-2xl">{player.emoji}</span>
+                <span className="font-medium">{player.nickname}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleAssign}
+            disabled={!selectedTarget || isAssigning}
+            className="w-full py-3 bg-gradient-to-r from-neon-rose to-orange-500 text-white rounded-lg font-bold disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-all hover:scale-[1.02] active:scale-95"
+          >
+            {isAssigning ? 'Assigning...' : 'Assign Forfeit'}
+          </button>
+        </div>
+      )}
+
+      {/* Not yet assigned — waiting */}
+      {!forfeit && !isWinner && (
+        <div className="text-center p-4 bg-slate-800 rounded-lg border border-slate-700 text-slate-400">
+          <p>Waiting for the winner to assign the forfeit...</p>
+        </div>
+      )}
+
+      {/* Forfeit assigned */}
+      {forfeit && (() => {
+        const target = towerState.players.find(p => p.userId === forfeit.toUserId);
+        const from = towerState.players.find(p => p.userId === forfeit.fromUserId);
+        return (
+          <div className="space-y-4">
+            <div className="text-center p-4 bg-rose-500/10 rounded-lg border border-rose-500/30">
+              <p className="text-slate-400 text-sm">Forfeit assigned to</p>
+              <p className="text-xl font-bold text-white mt-1">
+                {target?.emoji} {target?.nickname}
+                {target?.userId === userId && <span className="text-neon-rose"> (You!)</span>}
+              </p>
+              <p className="text-slate-500 text-xs mt-1">by {from?.nickname}</p>
+            </div>
+            {isHost && (
+              <button
+                onClick={onClose}
+                className="w-full py-3 bg-slate-700 text-white rounded-lg font-bold cursor-pointer hover:bg-slate-600 transition-all"
+              >
+                Done — Close Game
+              </button>
+            )}
+            {!isHost && (
+              <p className="text-center text-slate-500 text-sm">Waiting for host to close...</p>
+            )}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/src/components/TowerHoldScreen.tsx
+++ b/src/components/TowerHoldScreen.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import TowerMeter from './TowerMeter';
+
+const TARGET = 0.82;
+// v=0.08, k=3; busts at t ≈ 4.17s
+const computeFill = (elapsedSeconds: number): number =>
+  (-1 / 3) * Math.log(Math.max(1e-9, 1 - 3 * 0.08 * elapsedSeconds));
+
+interface TowerHoldScreenProps {
+  playerName: string;
+  emoji: string;
+  onSubmit: (fill: number) => Promise<void>;
+}
+
+export default function TowerHoldScreen({ playerName, emoji, onSubmit }: TowerHoldScreenProps) {
+  const [phase, setPhase] = useState<'countdown' | 'idle' | 'holding' | 'releasing'>('countdown');
+  const [countdown, setCountdown] = useState(3);
+  const [displayFill, setDisplayFill] = useState(0);
+  const [submitted, setSubmitted] = useState(false);
+
+  const holdStartRef = useRef<number | null>(null);
+  const fillRef = useRef(0);
+  const rafIdRef = useRef<number | null>(null);
+
+  // 3-second countdown on mount
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCountdown(c => {
+        if (c <= 1) {
+          clearInterval(id);
+          setPhase('idle');
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const cancelRaf = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+  }, []);
+
+  const submit = useCallback(async (fill: number) => {
+    if (submitted) return;
+    setSubmitted(true);
+    cancelRaf();
+    setPhase('releasing');
+    await onSubmit(fill);
+  }, [submitted, cancelRaf, onSubmit]);
+
+  const startHolding = useCallback(() => {
+    if (phase !== 'idle' || submitted) return;
+    holdStartRef.current = performance.now();
+    setPhase('holding');
+
+    const tick = () => {
+      if (holdStartRef.current === null) return;
+      const elapsed = (performance.now() - holdStartRef.current) / 1000;
+      const fill = computeFill(elapsed);
+      fillRef.current = fill;
+      setDisplayFill(fill);
+
+      if (fill >= 1.0) {
+        submit(fill);
+        return;
+      }
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+    rafIdRef.current = requestAnimationFrame(tick);
+  }, [phase, submitted, submit]);
+
+  const stopHolding = useCallback(() => {
+    if (phase !== 'holding') return;
+    submit(fillRef.current);
+  }, [phase, submit]);
+
+  if (phase === 'countdown') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-6">
+        <p className="text-slate-400 font-medium">Get ready, {emoji} {playerName}!</p>
+        <div className="text-8xl font-display font-black text-neon-violet animate-pulse">{countdown}</div>
+        <p className="text-slate-500 text-sm">Hold the button to fill the tower</p>
+      </div>
+    );
+  }
+
+  if (phase === 'releasing') {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4">
+        <p className="text-slate-400 text-lg">Submitting...</p>
+        <TowerMeter fill={displayFill} isActive={false} target={TARGET} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-6 select-none">
+      <p className="text-slate-300 font-medium text-lg">
+        {emoji} <span className="text-white font-bold">{playerName}</span> — your turn!
+      </p>
+
+      <div className="flex items-center gap-6">
+        <TowerMeter fill={displayFill} isActive={phase === 'holding'} target={TARGET} />
+        <div className="text-left space-y-2">
+          <p className="text-slate-400 text-sm">Target: <span className="text-neon-emerald font-bold">82%</span></p>
+          <p className="text-slate-400 text-sm">Fill: <span className="text-white font-mono">{(displayFill * 100).toFixed(1)}%</span></p>
+          {displayFill > 0.80 && (
+            <p className="text-rose-400 text-sm font-bold animate-pulse">DANGER!</p>
+          )}
+        </div>
+      </div>
+
+      <button
+        onPointerDown={startHolding}
+        onPointerUp={stopHolding}
+        onPointerLeave={stopHolding}
+        disabled={submitted}
+        className={`w-48 h-48 rounded-full text-white font-display font-black text-2xl transition-all duration-100 cursor-pointer select-none touch-none
+          ${phase === 'holding'
+            ? 'bg-gradient-to-br from-neon-violet to-primary scale-95 shadow-neon-violet'
+            : 'bg-slate-800 border-2 border-neon-violet hover:bg-slate-700 active:scale-95'
+          }
+          disabled:opacity-50 disabled:cursor-not-allowed`}
+      >
+        {phase === 'holding' ? 'HOLD!' : 'HOLD'}
+      </button>
+
+      <p className="text-slate-500 text-xs">Release to stop. Don&apos;t bust at 100%!</p>
+    </div>
+  );
+}

--- a/src/components/TowerLobbyScreen.tsx
+++ b/src/components/TowerLobbyScreen.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import { TowerState } from '@/types/tower';
+
+const EMOJIS = ['🎯', '😎', '👻', '🤠', '🦊', '👽'];
+
+interface TowerLobbyScreenProps {
+  towerState: TowerState;
+  userId: string | null;
+  onJoin: (nickname: string, emoji: string) => Promise<void>;
+  onStart: () => Promise<void>;
+  isJoining: boolean;
+}
+
+export default function TowerLobbyScreen({
+  towerState,
+  userId,
+  onJoin,
+  onStart,
+  isJoining,
+}: TowerLobbyScreenProps) {
+  const [nickname, setNickname] = useState('');
+  const [emoji, setEmoji] = useState(EMOJIS[0]);
+
+  const isHost = userId === towerState.host;
+  const isInGame = towerState.players.some(p => p.userId === userId);
+  const canStart = isHost && towerState.players.length >= 2;
+
+  const handleJoin = async () => {
+    if (!nickname.trim() || isJoining) return;
+    await onJoin(nickname.trim(), emoji);
+  };
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl shadow-neon-violet p-6 w-full max-w-md">
+      <h2 className="text-3xl font-display font-black text-center mb-2 bg-gradient-to-r from-neon-rose to-orange-400 bg-clip-text text-transparent">
+        Tower Game
+      </h2>
+      <p className="text-center text-slate-500 text-sm mb-6">
+        Hold to fill. Get closest to 82% without busting.
+      </p>
+
+      {/* Host dare preview */}
+      {towerState.hostDare && (
+        <div className="mb-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-300 text-sm">
+          <span className="font-bold">Dare on the table:</span> {towerState.hostDare}
+        </div>
+      )}
+
+      {/* Player list */}
+      <div className="mb-6">
+        <h3 className="font-semibold text-slate-300 mb-2">
+          Players Joined ({towerState.players.length})
+        </h3>
+        <ul className="space-y-2 max-h-40 overflow-y-auto bg-black/40 rounded-lg p-3 border border-slate-800">
+          {towerState.players.map(player => (
+            <li
+              key={player.userId}
+              className="flex items-center gap-2 p-2 bg-slate-800 rounded border border-slate-700 text-white"
+            >
+              <span className="text-2xl">{player.emoji}</span>
+              <span className="font-medium">
+                {player.nickname}
+                {player.userId === towerState.host && (
+                  <span className="ml-2 text-xs bg-yellow-500/20 text-yellow-300 px-2 py-0.5 rounded-full border border-yellow-500/30">
+                    Host
+                  </span>
+                )}
+                {player.userId === userId && (
+                  <span className="ml-2 text-xs bg-violet-500/20 text-violet-300 px-2 py-0.5 rounded-full border border-violet-500/30">
+                    You
+                  </span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {!isInGame ? (
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-400 mb-1">Your Nickname</label>
+            <input
+              type="text"
+              value={nickname}
+              onChange={e => setNickname(e.target.value)}
+              placeholder="Enter nickname"
+              className="w-full px-4 py-2 bg-black/40 border border-slate-700 rounded-lg focus:ring-2 focus:ring-neon-rose focus:border-neon-rose outline-none text-white placeholder-slate-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-400 mb-1">Choose Emoji</label>
+            <div className="flex gap-2">
+              {EMOJIS.map(e => (
+                <button
+                  key={e}
+                  onClick={() => setEmoji(e)}
+                  className={`text-2xl p-2 rounded-lg border cursor-pointer transition-colors ${
+                    emoji === e
+                      ? 'bg-rose-500/20 border-neon-rose'
+                      : 'bg-slate-800 border-slate-700 hover:bg-slate-700'
+                  }`}
+                >
+                  {e}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={handleJoin}
+            disabled={!nickname.trim() || isJoining}
+            className="w-full py-3 bg-gradient-to-r from-neon-rose to-orange-500 text-white rounded-lg font-bold disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-all hover:scale-[1.02] active:scale-95"
+          >
+            {isJoining ? 'Joining...' : 'Join Game'}
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="text-center p-4 bg-emerald-500/10 text-emerald-400 rounded-lg border border-emerald-500/30">
+            <p className="font-medium">You&apos;re in!</p>
+            <p className="text-sm mt-1 text-emerald-500/80">
+              {isHost ? 'Start when everyone is ready.' : 'Waiting for host to start...'}
+            </p>
+          </div>
+          {isHost && (
+            <button
+              onClick={onStart}
+              disabled={!canStart}
+              className="w-full py-3 bg-gradient-to-r from-neon-rose to-orange-500 text-white rounded-lg font-bold font-display text-lg disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer transition-all hover:scale-[1.02] active:scale-95 shadow-neon-rose"
+            >
+              {towerState.players.length < 2 ? 'Waiting for more players...' : 'Start Game!'}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TowerMeter.tsx
+++ b/src/components/TowerMeter.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+interface TowerMeterProps {
+  fill: number;       // 0–1.0
+  isActive: boolean;
+  target?: number;    // default 0.82
+}
+
+export default function TowerMeter({ fill, isActive, target = 0.82 }: TowerMeterProps) {
+  const pct = Math.min(fill * 100, 100);
+  const isShaking = fill > 0.75;
+  const isDanger = fill > 0.80;
+
+  return (
+    <div
+      className={`relative w-16 h-64 rounded-xl overflow-hidden border-2 transition-colors duration-150 ${
+        isDanger ? 'border-rose-500 shadow-neon-rose' : isActive ? 'border-neon-violet shadow-neon-violet' : 'border-slate-700'
+      } ${isShaking ? 'animate-[shake_0.15s_infinite]' : ''}`}
+      style={{ background: '#0a0a14' }}
+    >
+      {/* Fill bar */}
+      <div
+        className="absolute bottom-0 left-0 right-0 transition-none"
+        style={{
+          height: `${pct}%`,
+          background: 'linear-gradient(to top, #8B5CF6, #6366F1, #F59E0B, #F43F5E)',
+        }}
+      />
+
+      {/* Danger overlay above 80% */}
+      {isDanger && (
+        <div
+          className="absolute left-0 right-0 border-t-2 border-dashed border-rose-400/60"
+          style={{ bottom: '80%', top: 0, background: 'rgba(239,68,68,0.08)' }}
+        />
+      )}
+
+      {/* Target line */}
+      <div
+        className="absolute left-0 right-0 border-t-2 border-neon-emerald"
+        style={{
+          bottom: `${target * 100}%`,
+          boxShadow: '0 0 6px 1px #10B981',
+        }}
+      >
+        <span className="absolute right-full mr-1 text-[10px] text-neon-emerald font-bold whitespace-nowrap leading-none -translate-y-1/2 top-0">
+          {Math.round(target * 100)}%
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TowerOverlay.tsx
+++ b/src/components/TowerOverlay.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { getClientPusher } from '@/lib/pusher-client';
+import { TowerState, TowerTurnResult } from '@/types/tower';
+import TowerLobbyScreen from './TowerLobbyScreen';
+import TowerHoldScreen from './TowerHoldScreen';
+import TowerWatchScreen from './TowerWatchScreen';
+import TowerForfeitScreen from './TowerForfeitScreen';
+import { ForfeitCategory } from '@/data/forfeits';
+
+interface TowerOverlayProps {
+  tableId: string;
+  onGameActiveChange?: (active: boolean) => void;
+}
+
+interface TurnResultOverlay {
+  result: TowerTurnResult;
+  show: boolean;
+}
+
+export default function TowerOverlay({ tableId, onGameActiveChange }: TowerOverlayProps) {
+  const [towerState, setTowerState] = useState<TowerState | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
+  const [isJoining, setIsJoining] = useState(false);
+  const [turnResult, setTurnResult] = useState<TurnResultOverlay | null>(null);
+  // activePlayerId tracks who should show hold screen (set by tower-turn-start)
+  const [activePlayerId, setActivePlayerId] = useState<string | null>(null);
+  const towerStateRef = useRef<TowerState | null>(null);
+
+  // Keep ref in sync for unload handler
+  useEffect(() => {
+    towerStateRef.current = towerState;
+  }, [towerState]);
+
+  // Notify parent of active state
+  useEffect(() => {
+    onGameActiveChange?.(towerState !== null);
+  }, [towerState, onGameActiveChange]);
+
+  useEffect(() => {
+    // Resolve userId
+    let storedId = localStorage.getItem('demo_user_id');
+    if (!storedId) {
+      storedId = `user_${Math.random().toString(36).substr(2, 9)}`;
+      localStorage.setItem('demo_user_id', storedId);
+    }
+    setUserId(storedId);
+
+    // Hydrate from server
+    const fetchState = async () => {
+      try {
+        const res = await fetch(`/api/tower/${tableId}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data.game) {
+            setTowerState(data.game);
+            if (data.game.status === 'PLAYER_TURN') {
+              const cp = data.game.players[data.game.currentPlayerIndex];
+              setActivePlayerId(cp?.userId ?? null);
+            }
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch tower state:', err);
+      }
+    };
+    fetchState();
+
+    // Pusher
+    const pusher = getClientPusher();
+    if (!pusher) return;
+
+    const channel = pusher.subscribe(`table-${tableId}`);
+
+    channel.bind('tower-updated', (data: TowerState) => {
+      setTowerState(data);
+    });
+
+    channel.bind('tower-turn-start', (data: { playerId: string; playerIndex: number }) => {
+      setActivePlayerId(data.playerId);
+      // Clear turn result overlay once new turn starts
+      setTurnResult(null);
+    });
+
+    channel.bind('tower-turn-result', (data: { result: TowerTurnResult }) => {
+      setTurnResult({ result: data.result, show: true });
+      // Auto-hide after 2s
+      setTimeout(() => setTurnResult(r => r ? { ...r, show: false } : null), 2000);
+    });
+
+    channel.bind('tower-round-end', (data: {
+      winnerId: string;
+      forfeitCategory: ForfeitCategory;
+      forfeitText: string;
+      results: TowerTurnResult[];
+    }) => {
+      setTowerState(prev => prev ? {
+        ...prev,
+        status: 'ROUND_END',
+        winnerId: data.winnerId,
+        forfeitCategory: data.forfeitCategory,
+        forfeitText: data.forfeitText,
+        results: data.results,
+      } : null);
+    });
+
+    channel.bind('tower-forfeit', (data: { forfeit: TowerState['forfeit'] }) => {
+      setTowerState(prev => prev ? { ...prev, status: 'FORFEIT', forfeit: data.forfeit } : null);
+    });
+
+    channel.bind('tower-lobby-closed', () => {
+      setTowerState(null);
+    });
+
+    return () => {
+      channel.unbind('tower-updated');
+      channel.unbind('tower-turn-start');
+      channel.unbind('tower-turn-result');
+      channel.unbind('tower-round-end');
+      channel.unbind('tower-forfeit');
+      channel.unbind('tower-lobby-closed');
+      channel.unsubscribe();
+    };
+  }, [tableId]);
+
+  // Cleanup on unload
+  useEffect(() => {
+    const handleUnload = () => {
+      const state = towerStateRef.current;
+      if (!state) return;
+      const currentUserId = localStorage.getItem('demo_user_id');
+      if (!currentUserId) return;
+
+      if (state.host === currentUserId && state.status === 'LOBBY') {
+        fetch('/api/tower/close', {
+          method: 'POST',
+          body: JSON.stringify({ tableId }),
+          keepalive: true,
+        });
+      } else if (state.host !== currentUserId && state.status === 'LOBBY') {
+        fetch('/api/tower/leave', {
+          method: 'POST',
+          body: JSON.stringify({ tableId, userId: currentUserId }),
+          keepalive: true,
+        });
+      }
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    return () => window.removeEventListener('beforeunload', handleUnload);
+  }, [tableId]);
+
+  const handleJoin = async (nickname: string, emoji: string) => {
+    if (!userId || isJoining) return;
+    setIsJoining(true);
+    try {
+      await fetch('/api/tower/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tableId, playerProfile: { userId, nickname, emoji } }),
+      });
+    } catch (err) {
+      console.error('Failed to join tower game:', err);
+    } finally {
+      setIsJoining(false);
+    }
+  };
+
+  const handleStart = async () => {
+    if (!userId) return;
+    try {
+      await fetch('/api/tower/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tableId, userId }),
+      });
+    } catch (err) {
+      console.error('Failed to start tower game:', err);
+    }
+  };
+
+  const handleSubmitTurn = async (fill: number) => {
+    if (!userId) return;
+    try {
+      await fetch('/api/tower/submit-turn', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tableId, userId, fill }),
+      });
+    } catch (err) {
+      console.error('Failed to submit turn:', err);
+    }
+  };
+
+  const handleAssignForfeit = async (targetUserId: string) => {
+    if (!userId) return;
+    await fetch('/api/tower/forfeit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId, winnerId: userId, targetUserId }),
+    });
+  };
+
+  const handleClose = async () => {
+    await fetch('/api/tower/close', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tableId }),
+    });
+    setTowerState(null);
+  };
+
+  if (!towerState) return null;
+
+  const currentPlayer = towerState.players[towerState.currentPlayerIndex];
+  const isMyTurn = activePlayerId === userId && towerState.status === 'PLAYER_TURN';
+
+  return (
+    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex flex-col items-center justify-start overflow-y-auto p-4 pt-8">
+      {/* Turn result overlay (2s flash) */}
+      {turnResult?.show && (
+        <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+          <div className={`px-8 py-6 rounded-2xl text-center shadow-2xl ${
+            turnResult.result.busted ? 'bg-rose-900 border border-rose-500' : 'bg-emerald-900 border border-emerald-500'
+          }`}>
+            {turnResult.result.busted ? (
+              <p className="text-4xl font-display font-black text-rose-300">BUSTED!</p>
+            ) : (
+              <p className="text-4xl font-display font-black text-emerald-300">
+                {(turnResult.result.fill * 100).toFixed(1)}%
+              </p>
+            )}
+            <p className="text-slate-400 text-sm mt-1">
+              {towerState.players.find(p => p.userId === turnResult.result.userId)?.nickname}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {towerState.status === 'LOBBY' && (
+        <TowerLobbyScreen
+          towerState={towerState}
+          userId={userId}
+          onJoin={handleJoin}
+          onStart={handleStart}
+          isJoining={isJoining}
+        />
+      )}
+
+      {towerState.status === 'PLAYER_TURN' && isMyTurn && !turnResult?.show && (
+        <TowerHoldScreen
+          playerName={towerState.players.find(p => p.userId === userId)?.nickname ?? ''}
+          emoji={towerState.players.find(p => p.userId === userId)?.emoji ?? ''}
+          onSubmit={handleSubmitTurn}
+        />
+      )}
+
+      {towerState.status === 'PLAYER_TURN' && !isMyTurn && !turnResult?.show && currentPlayer && (
+        <TowerWatchScreen currentPlayer={currentPlayer} />
+      )}
+
+      {towerState.status === 'ROUND_END' && (
+        <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 w-full max-w-md">
+          <h2 className="text-3xl font-display font-black text-center mb-4 bg-gradient-to-r from-neon-rose to-orange-400 bg-clip-text text-transparent">
+            Leaderboard
+          </h2>
+          <ul className="space-y-2 mb-6">
+            {[...towerState.results]
+              .sort((a, b) => {
+                // Sort: non-busted desc, then busted desc
+                if (a.busted !== b.busted) return a.busted ? 1 : -1;
+                return b.fill - a.fill;
+              })
+              .map((r, i) => {
+                const player = towerState.players.find(p => p.userId === r.userId);
+                const isWinner = r.userId === towerState.winnerId;
+                return (
+                  <li
+                    key={r.userId}
+                    className={`flex items-center gap-3 p-3 rounded-lg border ${
+                      isWinner
+                        ? 'bg-emerald-500/10 border-neon-emerald text-emerald-300'
+                        : 'bg-slate-800 border-slate-700 text-white'
+                    }`}
+                  >
+                    <span className="text-slate-500 font-mono text-sm w-4">{i + 1}</span>
+                    <span className="text-xl">{player?.emoji}</span>
+                    <span className="flex-1 font-medium">{player?.nickname}</span>
+                    <span className={`font-mono text-sm ${r.busted ? 'text-rose-400' : 'text-white'}`}>
+                      {r.busted ? 'BUST' : `${(r.fill * 100).toFixed(1)}%`}
+                    </span>
+                    {isWinner && <span className="text-neon-emerald text-xs font-bold">WIN</span>}
+                  </li>
+                );
+              })}
+          </ul>
+        </div>
+      )}
+
+      {(towerState.status === 'FORFEIT' || (towerState.status === 'ROUND_END' && !!towerState.forfeitText)) && (
+        <div className="w-full max-w-md mt-4">
+          <TowerForfeitScreen
+            towerState={towerState}
+            userId={userId}
+            onAssignForfeit={handleAssignForfeit}
+            onClose={handleClose}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TowerWatchScreen.tsx
+++ b/src/components/TowerWatchScreen.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { PlayerProfile } from '@/types/game';
+import TowerMeter from './TowerMeter';
+
+interface TowerWatchScreenProps {
+  currentPlayer: PlayerProfile;
+}
+
+export default function TowerWatchScreen({ currentPlayer }: TowerWatchScreenProps) {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <p className="text-slate-300 text-lg">
+        Waiting for <span className="text-white font-bold">{currentPlayer.emoji} {currentPlayer.nickname}</span> to go...
+      </p>
+
+      <div className="relative">
+        <TowerMeter fill={0} isActive={false} />
+        {/* Pulsing placeholder overlay */}
+        <div className="absolute inset-0 rounded-xl animate-pulse bg-slate-700/20" />
+      </div>
+
+      <p className="text-slate-500 text-sm">Cheering them on...</p>
+    </div>
+  );
+}

--- a/src/components/__tests__/TowerOverlay.test.tsx
+++ b/src/components/__tests__/TowerOverlay.test.tsx
@@ -1,0 +1,138 @@
+import { expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import TowerOverlay from '../TowerOverlay';
+import { TowerState } from '@/types/tower';
+
+vi.mock('@/lib/pusher-client', () => ({
+  getClientPusher: vi.fn(() => ({
+    subscribe: vi.fn(() => ({
+      bind: vi.fn(),
+      unbind_all: vi.fn(),
+      unsubscribe: vi.fn(),
+    })),
+  })),
+}));
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  localStorage.setItem('demo_user_id', 'user_1');
+  vi.clearAllMocks();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.removeChild(container);
+});
+
+const mockFetch = (response: object | null, ok = true) => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok,
+      json: () => Promise.resolve(response),
+    })
+  ) as unknown as typeof fetch;
+};
+
+test('renders null when no active tower game (404 response)', async () => {
+  mockFetch({ error: 'Not found' }, false);
+  const { container: c } = render(<TowerOverlay tableId="t1" />, { container });
+  await new Promise(r => setTimeout(r, 50));
+  // Overlay div should not be present
+  expect(c.querySelector('.fixed')).toBeNull();
+});
+
+test('renders lobby when status LOBBY', async () => {
+  const state: TowerState = {
+    status: 'LOBBY',
+    host: 'user_1',
+    players: [{ userId: 'user_1', nickname: 'Host', emoji: '👑' }],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockFetch({ game: state });
+  const { container: c } = render(<TowerOverlay tableId="t1" />, { container });
+  await screen.findByText('Tower Game');
+  expect(within(c).getByText('Tower Game')).toBeTruthy();
+});
+
+test('Start Game button disabled with < 2 players', async () => {
+  const state: TowerState = {
+    status: 'LOBBY',
+    host: 'user_1',
+    players: [{ userId: 'user_1', nickname: 'Host', emoji: '👑' }],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockFetch({ game: state });
+  const { container: c } = render(<TowerOverlay tableId="t1" />, { container });
+  await screen.findByText('Tower Game');
+  const btns = within(c).getAllByRole('button');
+  const startBtn = btns.find(b => /Waiting for more players/.test(b.textContent ?? ''));
+  expect(startBtn).toBeDefined();
+  expect(startBtn).toHaveProperty('disabled', true);
+});
+
+test('shows hold screen for current player', async () => {
+  const state: TowerState = {
+    status: 'PLAYER_TURN',
+    host: 'user_1',
+    players: [
+      { userId: 'user_1', nickname: 'Host', emoji: '👑' },
+      { userId: 'user_2', nickname: 'Guest', emoji: '😎' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockFetch({ game: state });
+  const { container: c } = render(<TowerOverlay tableId="t1" />, { container });
+  // activePlayerId is set from tower-turn-start event; on hydrate we set it from currentPlayerIndex
+  await screen.findByText(/Get ready/);
+  expect(within(c).getByText(/Get ready/)).toBeTruthy();
+});
+
+test('shows watch screen when not current player', async () => {
+  const state: TowerState = {
+    status: 'PLAYER_TURN',
+    host: 'user_1',
+    players: [
+      { userId: 'user_2', nickname: 'OtherPerson', emoji: '😎' },
+      { userId: 'user_1', nickname: 'Host', emoji: '👑' },
+    ],
+    roundId: 'r1',
+    currentPlayerIndex: 0, // user_2's turn
+    results: [],
+  };
+  mockFetch({ game: state });
+  const { container: c } = render(<TowerOverlay tableId="t1" />, { container });
+  await screen.findByText(/Waiting for/);
+  expect(within(c).getByText(/OtherPerson/)).toBeTruthy();
+});
+
+test('calls onGameActiveChange(true) when game state arrives', async () => {
+  const onChange = vi.fn();
+  const state: TowerState = {
+    status: 'LOBBY',
+    host: 'user_1',
+    players: [{ userId: 'user_1', nickname: 'Host', emoji: '👑' }],
+    roundId: 'r1',
+    currentPlayerIndex: 0,
+    results: [],
+  };
+  mockFetch({ game: state });
+  render(<TowerOverlay tableId="t1" onGameActiveChange={onChange} />, { container });
+  await screen.findByText('Tower Game');
+  expect(onChange).toHaveBeenCalledWith(true);
+});
+
+test('calls onGameActiveChange(false) when no game', async () => {
+  const onChange = vi.fn();
+  mockFetch({ error: 'Not found' }, false);
+  render(<TowerOverlay tableId="t1" onGameActiveChange={onChange} />, { container });
+  await new Promise(r => setTimeout(r, 50));
+  expect(onChange).toHaveBeenCalledWith(false);
+});

--- a/src/data/forfeits.ts
+++ b/src/data/forfeits.ts
@@ -1,0 +1,41 @@
+export type ForfeitCategory = 'dare' | 'drink' | 'pay';
+
+export interface ForfeitOption {
+  category: ForfeitCategory;
+  text: string;
+}
+
+export const DRINK_FORFEITS: string[] = [
+  'Finish your current drink.',
+  'Buy the table a round of shots.',
+  'Order the most expensive drink on the menu and share it.',
+  'Down whatever is in front of you.',
+];
+
+export const PAY_FORFEITS: string[] = [
+  'Pay for the next round.',
+  'Cover the tab for everyone playing.',
+  'Buy drinks for all players.',
+];
+
+/**
+ * Builds the forfeit pool. If the host set a custom dare, it is included as
+ * the sole "dare" option. Drink and pay options are always included.
+ */
+export function buildForfeitPool(hostDare?: string): ForfeitOption[] {
+  const pool: ForfeitOption[] = [];
+  if (hostDare?.trim()) {
+    pool.push({ category: 'dare', text: hostDare.trim() });
+  }
+  DRINK_FORFEITS.forEach(text => pool.push({ category: 'drink', text }));
+  PAY_FORFEITS.forEach(text => pool.push({ category: 'pay', text }));
+  return pool;
+}
+
+export function pickRandomForfeit(hostDare?: string): ForfeitOption {
+  if (hostDare?.trim()) {
+    return { category: 'dare', text: hostDare.trim() };
+  }
+  const pool = buildForfeitPool();
+  return pool[Math.floor(Math.random() * pool.length)];
+}

--- a/src/types/tower.ts
+++ b/src/types/tower.ts
@@ -1,0 +1,31 @@
+import { PlayerProfile } from '@/types/game';
+import { ForfeitCategory } from '@/data/forfeits';
+
+export type TowerStatus = 'LOBBY' | 'PLAYER_TURN' | 'ROUND_END' | 'FORFEIT';
+
+export interface TowerTurnResult {
+  userId: string;
+  fill: number;    // 0–1.0 (server-clamped)
+  busted: boolean; // server-computed: submitted fill >= 1.0
+}
+
+export interface TowerForfeit {
+  fromUserId: string;
+  toUserId: string;
+  text: string;
+  category: ForfeitCategory;
+}
+
+export interface TowerState {
+  status: TowerStatus;
+  host: string;
+  players: PlayerProfile[];
+  roundId: string;
+  currentPlayerIndex: number;
+  results: TowerTurnResult[];
+  hostDare?: string;         // host-entered dare text, set at LOBBY
+  winnerId?: string;         // set at ROUND_END
+  forfeitCategory?: ForfeitCategory;  // set at ROUND_END
+  forfeitText?: string;      // set at ROUND_END
+  forfeit?: TowerForfeit;    // set at FORFEIT after winner assigns
+}


### PR DESCRIPTION
## Summary

- New **Tower Game** mode alongside Drink Roulette — players hold to fill a pressure meter, targeting ~82% without busting; winner picks a forfeit for the loser
- Full game flow: lobby → hold → watch others → forfeit screen
- Tower API routes: `create`, `join`, `start`, `submit-turn`, `forfeit`, `leave`, `close`
- Table page now shows both game CTAs; both are disabled while any game is active
- `pay/route`: delete Redis key after payment so a new game can start immediately
- `GameOverlay`: host fallback to show overlay instantly without waiting for Pusher, optimistic clear on payment, granular event unbinding

## Test plan

- [x] Start a Tower Game as host, join as guest — verify lobby shows all players
- [x] Hold the meter — verify fill animation and bust detection work
- [x] Complete a round — verify forfeit screen appears for the loser
- [x] Play a Drink Roulette game — verify Tower Game button is disabled while active and vice versa
- [x] Run `npm run test` — all tests pass