### PR TITLE
fix: abandon iOS hold haptics for a long buzz at the end

### DIFF
--- a/src/components/TowerHoldScreen.tsx
+++ b/src/components/TowerHoldScreen.tsx
@@ -35,28 +35,22 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
     }
   }, []);
 
-  const submit = useCallback(async (fill: number) => {
+  const submit = useCallback(async (fill: number, isUserAction: boolean) => {
     if (submitted) return;
     setSubmitted(true);
     cancelRaf();
     cancelHaptic?.();
+    if (isUserAction) {
+      haptic('buzz'); // Play long buzz immediately if user released
+    }
     setPhase('releasing');
     await onSubmit(fill);
-  }, [submitted, cancelRaf, cancelHaptic, onSubmit]);
+  }, [submitted, cancelRaf, cancelHaptic, haptic, onSubmit]);
 
   const startHolding = useCallback(() => {
     if (phase !== 'idle' || submitted) return;
     holdStartRef.current = performance.now();
     setPhase('holding');
-
-    // Pre-compute and fire the entire hold pattern synchronously so iOS respects it
-    haptic([
-      { duration: 1000, intensity: 1 },
-      { delay: 10, duration: 1000, intensity: 1 },
-      { delay: 10, duration: 1000, intensity: 1 },
-      { delay: 10, duration: 1000, intensity: 1 },
-      { delay: 10, duration: 1000, intensity: 1 }
-    ]);
 
     const tick = () => {
       if (holdStartRef.current === null) return;
@@ -67,18 +61,26 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
       onProgress?.(fill);
 
       if (fill >= 1.0) {
-        submit(fill);
+        submit(fill, false); // Not a direct user interaction, might not vibrate on iOS
         return;
       }
       rafIdRef.current = requestAnimationFrame(tick);
     };
     rafIdRef.current = requestAnimationFrame(tick);
-  }, [phase, submitted, submit]);
+  }, [phase, submitted, submit, onProgress]);
 
   const stopHolding = useCallback(() => {
-    if (phase !== 'holding') return;
-    submit(fillRef.current);
-  }, [phase, submit]);
+    if (phase !== 'holding') {
+      // If they already busted while holding, this release event is a trusted user action
+      // so we can finally fire the buzz now that they let go!
+      if (submitted) {
+        cancelHaptic?.();
+        haptic('buzz');
+      }
+      return;
+    }
+    submit(fillRef.current, true);
+  }, [phase, submit, submitted, haptic, cancelHaptic]);
 
   if (phase === 'releasing') {
     return (

--- a/src/components/TowerOverlay.tsx
+++ b/src/components/TowerOverlay.tsx
@@ -96,24 +96,12 @@ export default function TowerOverlay({ tableId, onGameActiveChange }: TowerOverl
       setTurnResult({ result: data.result, show: true });
       setCurrentFill(data.result.busted ? 1.0 : data.result.fill);
       
-      // Haptic feedback for result
-      if (data.result.busted) {
-        haptic('error');
-      } else {
-        haptic('success');
-      }
-
       // Auto-hide after 2s
       setTimeout(() => setTurnResult(r => r ? { ...r, show: false } : null), 2000);
     });
 
     channel.bind('tower-turn-progress', (data: { userId: string, fill: number }) => {
       setCurrentFill(data.fill);
-      // Continuous haptic pulse based on fill level for WATCHERS
-      if (data.userId !== userId && data.fill > 0 && data.fill < 1.0) {
-        // Since we only receive this every ~150ms, just pulse once per update
-        haptic([{ duration: 30, intensity: Math.max(0.2, data.fill) }]);
-      }
     });
 
     channel.bind('tower-round-end', (data: {


### PR DESCRIPTION
Removed the continuous vibration while holding, as iOS strictly prevents hardware access inside background loops/animations. Instead, we now deliver a single, satisfying long 'buzz' precisely when the player lifts their finger from the button, satisfying the iOS 'trusted user gesture' requirement.