### PR TITLE
fix: show minus button immediately after first add

### DIFF
--- a/src/components/menu/MenuItem.test.tsx
+++ b/src/components/menu/MenuItem.test.tsx
@@ -12,10 +12,12 @@ describe('MenuItem Component - Quantity Controls', () => {
     expect(screen.getByRole('button', { name: /add to cart/i })).toBeDefined();
   });
 
-  it('shows + button when item quantity is 1', () => {
+  it('shows - N + badge when item quantity is 1', () => {
     useCartStore.getState().addItem({ id: 'test-1', title: 'Test Item', price: 10.00, quantity: 1 });
     render(<MenuItem id="test-1" title="Test Item" price={10.00} imgUrl="/placeholder.png" />);
-    expect(screen.getByRole('button', { name: /add to cart/i })).toBeDefined();
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByRole('button', { name: /decrease quantity/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /increase quantity/i })).toBeDefined();
   });
 
   it('shows - N + badge when item quantity is 2 or more', () => {

--- a/src/components/menu/MenuItem.tsx
+++ b/src/components/menu/MenuItem.tsx
@@ -44,7 +44,7 @@ export const MenuItem: React.FC<MenuItemProps> = ({ id, title, price, descriptio
       </Link>
       <div className="relative w-[104px] h-[104px] rounded-md overflow-hidden bg-muted flex-shrink-0">
         <img src={imgUrl} alt={title} className="object-cover w-full h-full" />
-        {quantity < 2 ? (
+        {quantity < 1 ? (
           <button
             className="absolute bottom-[-12px] right-2 w-8 h-8 rounded-full bg-background border shadow-sm flex items-center justify-center translate-y-[-50%] hover:bg-muted transition-colors"
             onClick={handleAdd}


### PR DESCRIPTION
## Summary
- Fix quick add button so minus button appears immediately after first add (qty=1), not just when qty >= 2
- Updated test to reflect new expected behavior

## Bug
After adding an item for the first time, the minus button was not appearing - users had to add a second item before they could decrement.