### PR TITLE
fix(menu): add scroll spy and click-to-scroll for category nav

### DIFF
--- a/src/app/table/[tableId]/__tests__/page.test.tsx
+++ b/src/app/table/[tableId]/__tests__/page.test.tsx
@@ -3,12 +3,23 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import React, { Suspense } from 'react';
 import Page from '../page';
 
+class IntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+vi.stubGlobal('IntersectionObserver', IntersectionObserver);
+Element.prototype.scrollIntoView = vi.fn();
+
 // Mock overlays to prevent Pusher/fetch errors
 vi.mock('@/components/GameOverlay', () => ({
   default: () => <div data-testid="game-overlay-mock" />
 }));
 vi.mock('@/components/TowerOverlay', () => ({
   default: () => <div data-testid="tower-overlay-mock" />
+}));
+vi.mock('@/components/menu/FloatingCartButton', () => ({
+  FloatingCartButton: () => <div data-testid="floating-cart-mock" />
 }));
 
 test('opens bottom sheet and shows stepper', async () => {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Search } from 'lucide-react';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
@@ -16,6 +16,45 @@ interface MenuProps {
 
 export default function Menu({ tableId }: MenuProps) {
   const [activeCategory, setActiveCategory] = useState(menuData[0]?.category || '');
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const category = entry.target.getAttribute('data-category');
+            if (category) {
+              setActiveCategory(category);
+            }
+          }
+        });
+      },
+      {
+        rootMargin: '-120px 0px -50% 0px',
+        threshold: 0,
+      }
+    );
+
+    menuData.forEach((cat) => {
+      const element = document.getElementById(`category-${cat.category}`);
+      if (element) {
+        observerRef.current?.observe(element);
+      }
+    });
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  const scrollToCategory = (category: string) => {
+    setActiveCategory(category);
+    const element = document.getElementById(`category-${category}`);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
 
   return (
     <div className="flex flex-col w-full max-w-4xl mx-auto">
@@ -35,7 +74,7 @@ export default function Menu({ tableId }: MenuProps) {
             {menuData.map((cat) => (
               <button
                 key={cat.category}
-                onClick={() => setActiveCategory(cat.category)}
+                onClick={() => scrollToCategory(cat.category)}
                 className={`text-sm font-semibold transition-colors px-4 py-3 border-b-2 ${
                   activeCategory === cat.category 
                     ? 'text-primary border-primary' 
@@ -53,7 +92,7 @@ export default function Menu({ tableId }: MenuProps) {
       {/* Menu List */}
       <main className="px-4 py-6 space-y-8">
         {menuData.map((cat) => (
-          <div key={cat.category} id={`category-${cat.category}`} className="scroll-mt-[120px]">
+          <div key={cat.category} id={`category-${cat.category}`} data-category={cat.category} className="scroll-mt-[120px]">
             <h2 className="text-xl font-bold mb-4">{cat.category}</h2>
             <div className="space-y-0">
               {cat.items.map((item, index) => {

--- a/src/components/__tests__/GameOverlay.test.tsx
+++ b/src/components/__tests__/GameOverlay.test.tsx
@@ -6,6 +6,7 @@ vi.mock('@/lib/pusher-client', () => ({
   getClientPusher: vi.fn(() => ({
     subscribe: vi.fn(() => ({
       bind: vi.fn(),
+      unbind: vi.fn(),
       unbind_all: vi.fn(),
       unsubscribe: vi.fn()
     }))

--- a/src/components/__tests__/Menu.test.tsx
+++ b/src/components/__tests__/Menu.test.tsx
@@ -2,6 +2,14 @@ import { expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Menu from '../Menu';
 
+class IntersectionObserver {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+vi.stubGlobal('IntersectionObserver', IntersectionObserver);
+Element.prototype.scrollIntoView = vi.fn();
+
 vi.mock('@/data/menu', () => ({
   menuData: [
     {

--- a/src/components/__tests__/TowerOverlay.test.tsx
+++ b/src/components/__tests__/TowerOverlay.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/lib/pusher-client', () => ({
   getClientPusher: vi.fn(() => ({
     subscribe: vi.fn(() => ({
       bind: vi.fn(),
+      unbind: vi.fn(),
       unbind_all: vi.fn(),
       unsubscribe: vi.fn(),
     })),


### PR DESCRIPTION
## Summary
- Add IntersectionObserver-based scroll spy to detect visible menu category while scrolling
- Auto-update active tab in sticky header as user scrolls
- Clicking tab scrolls smoothly to that section

## Test Plan
- [x] 52 tests passing
- [x] Build passes
- [x] Code review complete (approved)