### PR TITLE
fix: trigger strong haptic when slotting into loser slot

### DIFF
--- a/src/components/barrel/BarrelGame.tsx
+++ b/src/components/barrel/BarrelGame.tsx
@@ -86,7 +86,11 @@ export default function BarrelGame({ tableId, onGameActiveChange }: BarrelGamePr
 
       pusherChannel.bind('barrel-sword-inserted', (data: { slotIndex: number; playerId: string }) => {
         setInsertingSlot(data.slotIndex);
-        haptic('tick');
+        if (data.playerId === userId && barrelStateRef.current?.triggerSlot === data.slotIndex) {
+          haptic('triggerLoser');
+        } else {
+          haptic('tick');
+        }
         setTimeout(() => setInsertingSlot(null), 300);
       });
 


### PR DESCRIPTION
## Summary
- Trigger `triggerLoser` haptic (strong buzz) when user slots into the loser slot
- Normal slots continue to use `tick` haptic