### PR TITLE
feat(cart): add inline quantity controls and item removal

### DIFF
--- a/src/app/table/[tableId]/cart/page.tsx
+++ b/src/app/table/[tableId]/cart/page.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { ChevronLeft, Info } from 'lucide-react';
+import { ChevronLeft, Info, Minus, Plus, Trash2 } from 'lucide-react';
 import { useRouter, useParams } from 'next/navigation';
 import { use } from 'react';
 import { BottomNav } from '@/components/menu/BottomNav';
@@ -15,6 +15,9 @@ export default function CartPage({ params }: { params: Promise<{ tableId: string
   const { tableId } = use(params);
   const items = useCartStore((state) => state.items);
   const totalPrice = useCartStore(selectTotalPrice);
+  const removeItem = useCartStore((state) => state.removeItem);
+  const updateItemQuantity = useCartStore((state) => state.updateItemQuantity);
+  const decrementItem = useCartStore((state) => state.decrementItem);
 
   return (
     <div className="flex flex-col h-screen bg-background">
@@ -42,8 +45,40 @@ export default function CartPage({ params }: { params: Promise<{ tableId: string
                     </div>
                   )}
                 </div>
-                <div className="font-semibold text-right pl-4">
-                  ${(item.price * item.quantity).toFixed(2)}
+                <div className="flex items-center gap-3">
+                  <span className="font-semibold text-right min-w-[60px]">
+                    ${(item.price * item.quantity).toFixed(2)}
+                  </span>
+                  <div className="flex items-center border rounded-full">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 rounded-full"
+                      onClick={() => decrementItem(item.cartItemId)}
+                      aria-label="Decrease quantity"
+                    >
+                      <Minus className="h-3 w-3" />
+                    </Button>
+                    <span className="w-6 text-center text-sm font-medium">{item.quantity}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 rounded-full"
+                      onClick={() => updateItemQuantity(item.cartItemId, item.quantity + 1)}
+                      aria-label="Increase quantity"
+                    >
+                      <Plus className="h-3 w-3" />
+                    </Button>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                    onClick={() => removeItem(item.cartItemId)}
+                    aria-label="Remove item"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
                 </div>
               </div>
             ))}

--- a/src/store/useCartStore.ts
+++ b/src/store/useCartStore.ts
@@ -16,6 +16,7 @@ interface CartState {
   addItem: (item: CartItemInput) => void;
   updateItemQuantity: (cartItemId: string, quantity: number) => void;
   decrementItem: (cartItemId: string) => void;
+  removeItem: (cartItemId: string) => void;
   getItemById: (menuItemId: string) => CartItem | undefined;
   clearCart: () => void;
 }
@@ -54,6 +55,9 @@ export const useCartStore = create<CartState>((set, get) => ({
       )
     };
   }),
+  removeItem: (cartItemId) => set((state) => ({
+    items: state.items.filter(item => item.cartItemId !== cartItemId)
+  })),
   clearCart: () => set({ items: [] }),
   addItem: (newItemInput) => set((state) => {
     const existingItemIndex = state.items.findIndex(


### PR DESCRIPTION
## Summary
- Add inline +/- quantity controls to cart items (Uber Eats-style)
- Add trash icon button to remove items from cart
- Add `removeItem` action to cart store

## Changes
- `src/store/useCartStore.ts`: Added `removeItem` action
- `src/app/table/[tableId]/cart/page.tsx`: Added quantity controls and remove button to each cart item