### PR TITLE
fix: change tower game win logic to closest to 82% instead of 100%

### DIFF
--- a/src/app/api/tower/submit-turn/route.ts
+++ b/src/app/api/tower/submit-turn/route.ts
@@ -62,15 +62,22 @@ export async function POST(request: Request) {
     }
 
     // All players done — compute winner and wrap up round
+    // Winner is closest to 0.82 (82%) without busting (going over 1.0)
+    // We compute the distance to 0.82.
+    const TARGET = 0.82;
     const nonBusted = state.results.filter(r => !r.busted);
     let winnerId: string;
 
     if (nonBusted.length > 0) {
-      // Closest to 1.0 without busting
-      const winner = nonBusted.reduce((best, r) => (r.fill > best.fill ? r : best));
+      // Closest to TARGET without busting
+      const winner = nonBusted.reduce((best, r) => {
+        const bestDist = Math.abs(best.fill - TARGET);
+        const rDist = Math.abs(r.fill - TARGET);
+        return rDist < bestDist ? r : best;
+      });
       winnerId = winner.userId;
     } else {
-      // All busted — highest fill still wins (closest to the edge)
+      // All busted — highest fill still wins (closest to 1.0)
       const winner = state.results.reduce((best, r) => (r.fill > best.fill ? r : best));
       winnerId = winner.userId;
     }

--- a/src/components/TowerOverlay.tsx
+++ b/src/components/TowerOverlay.tsx
@@ -309,6 +309,11 @@ export default function TowerOverlay({ tableId, onGameActiveChange }: TowerOverl
             {[...towerState.results]
               .sort((a, b) => {
                 if (a.busted !== b.busted) return a.busted ? 1 : -1;
+                if (!a.busted) {
+                  // Both not busted: sort by closest to 0.82
+                  return Math.abs(a.fill - 0.82) - Math.abs(b.fill - 0.82);
+                }
+                // Both busted: sort by highest fill
                 return b.fill - a.fill;
               })
               .map((r, i) => {
@@ -339,8 +344,11 @@ export default function TowerOverlay({ tableId, onGameActiveChange }: TowerOverl
           <ul className="space-y-2 mb-6">
             {[...towerState.results]
               .sort((a, b) => {
-                // Sort: non-busted desc, then busted desc
+                // Sort: non-busted (closest to 0.82), then busted (highest fill)
                 if (a.busted !== b.busted) return a.busted ? 1 : -1;
+                if (!a.busted) {
+                  return Math.abs(a.fill - 0.82) - Math.abs(b.fill - 0.82);
+                }
                 return b.fill - a.fill;
               })
               .map((r, i) => {


### PR DESCRIPTION
## Summary
- Modifies the game's victory condition logic in the `submit-turn` API route so that the winner is now the player who gets closest to `0.82` (82%), rather than `1.0` (100%).
- Modifies the frontend leaderboard sorting in `TowerOverlay.tsx` to reflect this new calculation: non-busted players are ranked by closest distance to `82%`. 
- Busted logic (filling over `1.0`) remains the same and busts are still ranked by highest fill underneath non-busted.

Resolves #34