### PR TITLE
Fix: Restore haptics abstraction and DRY principles

### DIFF
--- a/src/components/HapticTester.tsx
+++ b/src/components/HapticTester.tsx
@@ -7,6 +7,10 @@ import { defaultPatterns } from "web-haptics";
 
 const PRESETS = [...Object.keys(defaultPatterns), ...Object.keys(HAPTIC_PATTERNS)];
 
+function isGameHapticPattern(preset: string): preset is keyof typeof HAPTIC_PATTERNS {
+  return preset in HAPTIC_PATTERNS;
+}
+
 export function HapticTester() {
   const [debugAudio, setDebugAudio] = useState(false);
   const [customInput, setCustomInput] = useState("100, 50, 100, 50, 200");
@@ -15,8 +19,8 @@ export function HapticTester() {
   const { trigger, isSupported } = useGameHaptics({ debug: debugAudio });
 
   const handlePresetClick = (preset: string) => {
-    if (preset in HAPTIC_PATTERNS) {
-      trigger(HAPTIC_PATTERNS[preset as keyof typeof HAPTIC_PATTERNS]);
+    if (isGameHapticPattern(preset)) {
+      trigger(HAPTIC_PATTERNS[preset]);
     } else {
       trigger(preset);
     }

--- a/src/components/HapticTester.tsx
+++ b/src/components/HapticTester.tsx
@@ -1,20 +1,25 @@
 "use client";
 
 import { useState } from "react";
-import { useWebHaptics } from "web-haptics/react";
+import { useGameHaptics } from "@/hooks/useGameHaptics";
+import { HAPTIC_PATTERNS } from "@/lib/haptics";
 import { defaultPatterns } from "web-haptics";
 
-const PRESETS = Object.keys(defaultPatterns);
+const PRESETS = [...Object.keys(defaultPatterns), ...Object.keys(HAPTIC_PATTERNS)];
 
 export function HapticTester() {
   const [debugAudio, setDebugAudio] = useState(false);
   const [customInput, setCustomInput] = useState("100, 50, 100, 50, 200");
   const [error, setError] = useState<string | null>(null);
 
-  const { trigger, isSupported } = useWebHaptics({ debug: debugAudio });
+  const { trigger, isSupported } = useGameHaptics({ debug: debugAudio });
 
   const handlePresetClick = (preset: string) => {
-    trigger(preset);
+    if (preset in HAPTIC_PATTERNS) {
+      trigger(HAPTIC_PATTERNS[preset as keyof typeof HAPTIC_PATTERNS]);
+    } else {
+      trigger(preset);
+    }
   };
 
   const handleCustomTrigger = () => {

--- a/src/components/TowerHoldScreen.tsx
+++ b/src/components/TowerHoldScreen.tsx
@@ -26,7 +26,7 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
   const rafIdRef = useRef<number | null>(null);
   const lastHapticRef = useRef<number>(0);
   
-  const { hapticBuzz, cancel: cancelHaptic } = useGameHaptics({ debug: false, showSwitch: true });
+  const { hapticBuzz, cancel: cancelHaptic } = useGameHaptics();
 
   const cancelRaf = useCallback(() => {
     if (rafIdRef.current !== null) {

--- a/src/components/TowerHoldScreen.tsx
+++ b/src/components/TowerHoldScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import TowerMeter from './TowerMeter';
-import { useWebHaptics } from 'web-haptics/react';
+import { useGameHaptics } from '@/hooks/useGameHaptics';
 
 const TARGET = 0.82;
 // v=0.08, k=3; busts at t ≈ 4.17s
@@ -26,7 +26,7 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
   const rafIdRef = useRef<number | null>(null);
   const lastHapticRef = useRef<number>(0);
   
-  const { trigger: haptic, cancel: cancelHaptic } = useWebHaptics({ debug: false, showSwitch: true });
+  const { hapticBuzz, cancel: cancelHaptic } = useGameHaptics({ debug: false, showSwitch: true });
 
   const cancelRaf = useCallback(() => {
     if (rafIdRef.current !== null) {
@@ -41,11 +41,11 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
     cancelRaf();
     cancelHaptic?.();
     if (isUserAction) {
-      haptic('buzz'); // Play long buzz immediately if user released
+      hapticBuzz(); // Play long buzz immediately if user released
     }
     setPhase('releasing');
     await onSubmit(fill);
-  }, [submitted, cancelRaf, cancelHaptic, haptic, onSubmit]);
+  }, [submitted, cancelRaf, cancelHaptic, hapticBuzz, onSubmit]);
 
   const startHolding = useCallback(() => {
     if (phase !== 'idle' || submitted) return;
@@ -75,12 +75,12 @@ export default function TowerHoldScreen({ playerName, emoji, onSubmit, onProgres
       // so we can finally fire the buzz now that they let go!
       if (submitted) {
         cancelHaptic?.();
-        haptic('buzz');
+        hapticBuzz();
       }
       return;
     }
     submit(fillRef.current, true);
-  }, [phase, submit, submitted, haptic, cancelHaptic]);
+  }, [phase, submit, submitted, hapticBuzz, cancelHaptic]);
 
   if (phase === 'releasing') {
     return (

--- a/src/components/barrel/BarrelGame.tsx
+++ b/src/components/barrel/BarrelGame.tsx
@@ -7,7 +7,7 @@ import { BarrelState } from '@/types/barrel';
 import LobbyScreen from './LobbyScreen';
 import PlayerTurnBanner from './PlayerTurnBanner';
 import RoundEndModal from './RoundEndModal';
-import { useWebHaptics } from 'web-haptics/react';
+import { useGameHaptics } from '@/hooks/useGameHaptics';
 
 const BarrelScene = dynamic(() => import('./BarrelScene'), { ssr: false });
 
@@ -30,7 +30,7 @@ export default function BarrelGame({ tableId, onGameActiveChange }: BarrelGamePr
   const piratePopTimeRef = useRef<number | null>(null);
   const piratePopTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { trigger: haptic } = useWebHaptics({ debug: false, showSwitch: true });
+  const { hapticLoser, hapticSuccess, hapticBuzz } = useGameHaptics();
 
   // Prevent hydration mismatch
   useEffect(() => {
@@ -92,15 +92,15 @@ export default function BarrelGame({ tableId, onGameActiveChange }: BarrelGamePr
       pusherChannel.bind('barrel-sword-inserted', (data: { slotIndex: number; playerId: string }) => {
         setInsertingSlot(data.slotIndex);
         if (data.playerId === userId && barrelStateRef.current?.triggerSlot === data.slotIndex) {
-          haptic([300, 100, 500]);
+          hapticLoser();
         } else {
-          haptic('success');
+          hapticSuccess();
         }
         setTimeout(() => setInsertingSlot(null), 300);
       });
 
       pusherChannel.bind('barrel-trigger-hit', () => {
-        haptic('buzz');
+        hapticBuzz();
       });
 
       pusherChannel.bind('barrel-game-over', () => {

--- a/src/hooks/useBarrelGame.ts
+++ b/src/hooks/useBarrelGame.ts
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { getClientPusher } from '@/lib/pusher-client';
 import { BarrelState } from '@/types/barrel';
-import { useWebHaptics } from 'web-haptics/react';
+import { useGameHaptics } from '@/hooks/useGameHaptics';
 
 interface UseBarrelGameOptions {
   tableId: string;
@@ -30,7 +30,7 @@ export function useBarrelGame({ tableId, onGameOver }: UseBarrelGameOptions): Us
   const [insertingSlot, setInsertingSlot] = useState<number | null>(null);
   const barrelStateRef = useRef<BarrelState | null>(null);
 
-  const { trigger: haptic } = useWebHaptics({ debug: false, showSwitch: true });
+  const { hapticTick, hapticLoser, hapticOthers } = useGameHaptics();
 
   useEffect(() => {
     barrelStateRef.current = barrelState;
@@ -82,7 +82,7 @@ export function useBarrelGame({ tableId, onGameOver }: UseBarrelGameOptions): Us
 
     channel.bind('barrel-sword-inserted', (data: { slotIndex: number; playerId: string }) => {
       setInsertingSlot(data.slotIndex);
-      haptic([10]);
+      hapticTick();
       setTimeout(() => setInsertingSlot(null), 500);
     });
 
@@ -90,9 +90,9 @@ export function useBarrelGame({ tableId, onGameOver }: UseBarrelGameOptions): Us
       setBarrelState(prev => prev ? { ...prev, loserId: data.userId } : null);
       
       if (data.userId === storedId) {
-        haptic([300, 100, 500]);
+        hapticLoser();
       } else {
-        haptic([150, 50, 150]);
+        hapticOthers();
       }
     });
 
@@ -105,7 +105,7 @@ export function useBarrelGame({ tableId, onGameOver }: UseBarrelGameOptions): Us
       channel.unbind_all();
       channel.unsubscribe();
     };
-  }, [tableId, haptic, onGameOver]);
+  }, [tableId, hapticTick, hapticLoser, hapticOthers, onGameOver]);
 
   const handleJoin = useCallback(async (nickname: string, emoji: string) => {
     if (!userId || isJoining) return;

--- a/src/hooks/useGameHaptics.ts
+++ b/src/hooks/useGameHaptics.ts
@@ -1,0 +1,30 @@
+import { useWebHaptics } from 'web-haptics/react';
+import { HAPTIC_PATTERNS } from '@/lib/haptics';
+
+interface UseGameHapticsOptions {
+  debug?: boolean;
+  showSwitch?: boolean;
+}
+
+export function useGameHaptics(options?: UseGameHapticsOptions) {
+  const { trigger, ...rest } = useWebHaptics({ 
+    debug: options?.debug ?? false, 
+    showSwitch: options?.showSwitch ?? true 
+  });
+
+  const hapticTick = () => trigger(HAPTIC_PATTERNS.tick);
+  const hapticLoser = () => trigger(HAPTIC_PATTERNS.loser);
+  const hapticOthers = () => trigger(HAPTIC_PATTERNS.others);
+  const hapticSuccess = () => trigger('success');
+  const hapticBuzz = () => trigger('buzz');
+
+  return {
+    trigger,
+    hapticTick,
+    hapticLoser,
+    hapticOthers,
+    hapticSuccess,
+    hapticBuzz,
+    ...rest,
+  };
+}

--- a/src/hooks/useGameHaptics.ts
+++ b/src/hooks/useGameHaptics.ts
@@ -6,10 +6,10 @@ interface UseGameHapticsOptions {
   showSwitch?: boolean;
 }
 
-export function useGameHaptics(options?: UseGameHapticsOptions) {
+export function useGameHaptics(options: UseGameHapticsOptions = { debug: false, showSwitch: true }) {
   const { trigger, ...rest } = useWebHaptics({ 
-    debug: options?.debug ?? false, 
-    showSwitch: options?.showSwitch ?? true 
+    debug: options.debug ?? false, 
+    showSwitch: options.showSwitch ?? true 
   });
 
   const hapticTick = () => trigger(HAPTIC_PATTERNS.tick);

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,5 @@
+export const HAPTIC_PATTERNS = {
+  tick: [10],
+  loser: [300, 100, 500],
+  others: [150, 50, 150],
+};


### PR DESCRIPTION
## Summary
- Resolves #46 
- Restored `src/lib/haptics.ts` to hold custom haptic patterns.
- Added `useGameHaptics` hook that abstracts `useWebHaptics` and exports named haptic trigger functions (like `hapticTick`, `hapticLoser`, etc.).
- Replaced hardcoded haptic vibration arrays in game components and hooks with the new abstraction.